### PR TITLE
Connector Setup (Acceptance API)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.venv
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,106 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# Mac
+._*
+.DS_Store
+
+# Custom stuff
+env.sh
+config.json
+.autoenv.zsh
+.vscode
+poetry.lock
+
+rsa-key
+tags
+singer-check-tap-data
+state.json

--- a/catalog.json
+++ b/catalog.json
@@ -1,0 +1,11277 @@
+{
+  "streams": [
+    {
+      "tap_stream_id": "company",
+      "schema": {
+        "properties": {
+          "Id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "Name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "EmailAddress": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Comments": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "VatNumber": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "HotelCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Fax": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "CreatedDateTime": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "LastUpdateDateTime": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Addresses": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "City": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "HouseNumber": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "State": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Street": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "ZipCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CountryCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LanguageCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Source": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "IsPrimary": {
+                  "type": "boolean"
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "PhoneNumbers": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "CountryAccessCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Number": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "IsPrimary": {
+                  "type": "boolean"
+                },
+                "Source": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "ExternalReferences": {
+            "items": {
+              "properties": {
+                "Code": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "TypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "SystemCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "Attributes": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "Code": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Value": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "TypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "StartDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "EndDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CreateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      },
+      "stream": "company",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "id"
+            ],
+            "forced-replication-method": "INCREMENTAL",
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "EmailAddress"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Comments"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "VatNumber"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "HotelCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Fax"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "CreatedDateTime"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "LastUpdateDateTime"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Addresses"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "PhoneNumbers"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "ExternalReferences"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Attributes"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "person",
+      "schema": {
+        "properties": {
+          "Id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "Title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Names": {
+            "items": {
+              "properties": {
+                "Title": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "FirstName": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastName": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Primary": {
+                  "type": "boolean"
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "EmailAddresses": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "Type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Value": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Verified": {
+                  "type": "boolean"
+                },
+                "Source": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "IsPrimary": {
+                  "type": "boolean"
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "LanguageCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "CountryCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Gender": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "DateOfBirth": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "HotelCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Source": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "JobTitle": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "IsMember": {
+            "type": "boolean"
+          },
+          "NewsletterSubscription": {
+            "type": "boolean"
+          },
+          "Company": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "Name": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "EmailAddress": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Comments": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "VatNumber": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "HotelCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Fax": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Addresses": {
+                  "items": {
+                    "properties": {
+                      "Id": {
+                        "type": [
+                          "null",
+                          "integer"
+                        ]
+                      },
+                      "City": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "HouseNumber": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "State": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "Street": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "ZipCode": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "CountryCode": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "LanguageCode": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "Source": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "Type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "IsPrimary": {
+                        "type": "boolean"
+                      },
+                      "CreatedDateTime": {
+                        "format": "date-time",
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "LastUpdateDateTime": {
+                        "format": "date-time",
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "type": [
+                    "null",
+                    "array"
+                  ]
+                },
+                "PhoneNumbers": {
+                  "items": {
+                    "properties": {
+                      "Id": {
+                        "type": [
+                          "null",
+                          "integer"
+                        ]
+                      },
+                      "CountryAccessCode": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "Number": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "IsPrimary": {
+                        "type": "boolean"
+                      },
+                      "Source": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "Type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "CreatedDateTime": {
+                        "format": "date-time",
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "LastUpdateDateTime": {
+                        "format": "date-time",
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "type": [
+                    "null",
+                    "array"
+                  ]
+                },
+                "ExternalReferences": {
+                  "items": {
+                    "properties": {
+                      "Code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "TypeCode": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "SystemCode": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "type": [
+                    "null",
+                    "array"
+                  ]
+                },
+                "Attributes": {
+                  "items": {
+                    "properties": {
+                      "Id": {
+                        "type": [
+                          "null",
+                          "integer"
+                        ]
+                      },
+                      "Code": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "Value": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "TypeCode": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "StartDateTime": {
+                        "format": "date-time",
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "EndDateTime": {
+                        "format": "date-time",
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "CreateDateTime": {
+                        "format": "date-time",
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "LastUpdateDateTime": {
+                        "format": "date-time",
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "type": [
+                    "null",
+                    "array"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "CompanyName": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ExternalReferences": {
+            "items": {
+              "properties": {
+                "Code": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "TypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "SystemCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "Attributes": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "Code": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Value": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "TypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "StartDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "EndDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CreateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "Addresses": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "City": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "HouseNumber": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "State": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Street": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "ZipCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CountryCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LanguageCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Source": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "IsPrimary": {
+                  "type": "boolean"
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "PhoneNumbers": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "CountryAccessCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Number": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "IsPrimary": {
+                  "type": "boolean"
+                },
+                "Source": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "DataConsents": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "Message": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Source": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "SubSource": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Given": {
+                  "type": "boolean"
+                },
+                "Type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "ValidUntil": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "PaymentMethods": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "TypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Code": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Name": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Value": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "SubTypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "PaymentIntegrationCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "PaymentIntegrationMerchantCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "ExpiryDate": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "Preferences": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "PersonId": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "ReservationId": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "Code": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Value": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "TypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Source": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "HotelCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "LoyaltyLevels": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "LevelCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Rank": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "ValidFrom": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "ValidUntil": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Source": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "StaySummaries": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "CurrencyCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "HotelCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastStayDate": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "NumberOfNights": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "NumberOfStays": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "StayTotalRevenue": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "StayTotalRevenueEnterprise": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "LastStayUnit": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastStayRevenue": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "Documents": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "PersonId": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "HotelCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Source": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Number": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Nationality": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "IssueCity": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "IssueCountry": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "PlaceOfBirth": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "ExpiryDate": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "IssueDate": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "IsPrimary": {
+                  "type": "boolean"
+                },
+                "LastChangedBySystem": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "GlobalStays": {
+            "properties": {
+              "CurrencyCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "LastStayDate": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "NumberOfNights": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "NumberOfStays": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "StayTotalRevenue": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "LastStayUnit": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "LastStayHotelCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "HotelDiversity": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "LastChangedBySystem": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "CreatedDateTime": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "LastUpdateDateTime": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      },
+      "stream": "person",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "id"
+            ],
+            "forced-replication-method": "INCREMENTAL",
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Title"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Names"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "EmailAddresses"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "LanguageCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "CountryCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Gender"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "DateOfBirth"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "HotelCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Source"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "JobTitle"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "IsMember"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "NewsletterSubscription"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Company"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "CompanyName"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "ExternalReferences"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Attributes"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Addresses"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "PhoneNumbers"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "DataConsents"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "PaymentMethods"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Preferences"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "LoyaltyLevels"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "StaySummaries"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Documents"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "GlobalStays"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "LastChangedBySystem"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "CreatedDateTime"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "LastUpdateDateTime"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "folio",
+      "schema": {
+        "properties": {
+          "Id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "HotelCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ReservationId": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "Total": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "VatTotal": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "InvoiceNumber": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "AdditionalInvoiceNumber": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "PrimaryPersonId": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "AgencyId": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "CompanyId": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "SourceCompanyId": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "System": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Status": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Addresses": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "City": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "HouseNumber": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "State": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Street": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "ZipCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CountryCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LanguageCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Source": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "IsPrimary": {
+                  "type": "boolean"
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "Lines": {
+            "items": {
+              "properties": {
+                "InvoiceLineCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Description": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Quantity": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "ArticleGroupCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "BillingGroupCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Total": {
+                  "type": [
+                    "null",
+                    "number"
+                  ]
+                },
+                "VatTotal": {
+                  "type": [
+                    "null",
+                    "number"
+                  ]
+                },
+                "PostingDate": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CustomReference": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CurrencyCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "IsDeleted": {
+                  "type": "boolean"
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastChangedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "CreatedDateTime": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "LastChangedDateTime": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      },
+      "stream": "folio",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "id"
+            ],
+            "forced-replication-method": "INCREMENTAL",
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "HotelCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "ReservationId"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Total"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "VatTotal"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "InvoiceNumber"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "AdditionalInvoiceNumber"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "PrimaryPersonId"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "AgencyId"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "CompanyId"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "SourceCompanyId"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "System"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Status"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Addresses"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Lines"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "CreatedDateTime"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "LastChangedDateTime"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "reservation",
+      "schema": {
+        "properties": {
+          "Id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "ArrivalDate": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "DepartureDate": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "HotelCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "UnitCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "UnitTypeCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "RequestedUnitTypeCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Status": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "NumberOfPersons": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "NumberOfChildren": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "NumberOfInfants": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "NumberOfUnits": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "NumberOfNights": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "Comments": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Source": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "SubSource": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "GroupCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "GuaranteeTypeCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "MarketCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "PromoCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ActualArrivalDate": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ActualDepartureDate": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Booker": {
+            "properties": {
+              "Id": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "Title": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Names": {
+                "items": {
+                  "properties": {
+                    "Title": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "FirstName": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastName": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Primary": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "EmailAddresses": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Verified": {
+                      "type": "boolean"
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "LanguageCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "CountryCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Gender": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "DateOfBirth": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "HotelCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Source": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "JobTitle": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "IsMember": {
+                "type": "boolean"
+              },
+              "NewsletterSubscription": {
+                "type": "boolean"
+              },
+              "Company": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Name": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "EmailAddress": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Comments": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "VatNumber": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HotelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Fax": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Addresses": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "City": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "HouseNumber": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "State": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Street": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "ZipCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CountryCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LanguageCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Source": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "IsPrimary": {
+                            "type": "boolean"
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "PhoneNumbers": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "CountryAccessCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Number": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "IsPrimary": {
+                            "type": "boolean"
+                          },
+                          "Source": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "ExternalReferences": {
+                      "items": {
+                        "properties": {
+                          "Code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "TypeCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "SystemCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "Attributes": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "Code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Value": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "TypeCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "StartDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "EndDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CreateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "CompanyName": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "ExternalReferences": {
+                "items": {
+                  "properties": {
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SystemCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Attributes": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "StartDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "EndDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Addresses": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "City": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HouseNumber": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "State": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Street": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ZipCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CountryCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LanguageCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "PhoneNumbers": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CountryAccessCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Number": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "DataConsents": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Message": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SubSource": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Given": {
+                      "type": "boolean"
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ValidUntil": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "PaymentMethods": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Name": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SubTypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "PaymentIntegrationCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "PaymentIntegrationMerchantCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ExpiryDate": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Preferences": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "PersonId": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "ReservationId": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HotelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "LoyaltyLevels": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "LevelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Rank": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "ValidFrom": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ValidUntil": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "StaySummaries": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CurrencyCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HotelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastStayDate": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "NumberOfNights": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "NumberOfStays": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "StayTotalRevenue": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "StayTotalRevenueEnterprise": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "LastStayUnit": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastStayRevenue": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Documents": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "PersonId": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "HotelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Number": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Nationality": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IssueCity": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IssueCountry": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "PlaceOfBirth": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ExpiryDate": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IssueDate": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "LastChangedBySystem": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "GlobalStays": {
+                "properties": {
+                  "CurrencyCode": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "LastStayDate": {
+                    "format": "date-time",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "NumberOfNights": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "NumberOfStays": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "StayTotalRevenue": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "LastStayUnit": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "LastStayHotelCode": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "HotelDiversity": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  }
+                },
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false
+              },
+              "LastChangedBySystem": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "CreatedDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "LastUpdateDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "PrimaryGuest": {
+            "properties": {
+              "Id": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "Title": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Names": {
+                "items": {
+                  "properties": {
+                    "Title": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "FirstName": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastName": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Primary": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "EmailAddresses": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Verified": {
+                      "type": "boolean"
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "LanguageCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "CountryCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Gender": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "DateOfBirth": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "HotelCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Source": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "JobTitle": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "IsMember": {
+                "type": "boolean"
+              },
+              "NewsletterSubscription": {
+                "type": "boolean"
+              },
+              "Company": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Name": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "EmailAddress": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Comments": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "VatNumber": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HotelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Fax": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Addresses": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "City": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "HouseNumber": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "State": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Street": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "ZipCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CountryCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LanguageCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Source": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "IsPrimary": {
+                            "type": "boolean"
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "PhoneNumbers": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "CountryAccessCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Number": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "IsPrimary": {
+                            "type": "boolean"
+                          },
+                          "Source": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "ExternalReferences": {
+                      "items": {
+                        "properties": {
+                          "Code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "TypeCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "SystemCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "Attributes": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "Code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Value": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "TypeCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "StartDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "EndDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CreateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "CompanyName": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "ExternalReferences": {
+                "items": {
+                  "properties": {
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SystemCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Attributes": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "StartDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "EndDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Addresses": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "City": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HouseNumber": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "State": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Street": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ZipCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CountryCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LanguageCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "PhoneNumbers": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CountryAccessCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Number": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "DataConsents": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Message": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SubSource": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Given": {
+                      "type": "boolean"
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ValidUntil": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "PaymentMethods": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Name": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SubTypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "PaymentIntegrationCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "PaymentIntegrationMerchantCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ExpiryDate": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Preferences": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "PersonId": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "ReservationId": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HotelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "LoyaltyLevels": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "LevelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Rank": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "ValidFrom": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ValidUntil": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "StaySummaries": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CurrencyCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HotelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastStayDate": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "NumberOfNights": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "NumberOfStays": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "StayTotalRevenue": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "StayTotalRevenueEnterprise": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "LastStayUnit": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastStayRevenue": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Documents": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "PersonId": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "HotelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Number": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Nationality": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IssueCity": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IssueCountry": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "PlaceOfBirth": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ExpiryDate": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IssueDate": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "LastChangedBySystem": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "GlobalStays": {
+                "properties": {
+                  "CurrencyCode": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "LastStayDate": {
+                    "format": "date-time",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "NumberOfNights": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "NumberOfStays": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "StayTotalRevenue": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "LastStayUnit": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "LastStayHotelCode": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "HotelDiversity": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  }
+                },
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false
+              },
+              "LastChangedBySystem": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "CreatedDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "LastUpdateDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "RatePlan": {
+            "properties": {
+              "Code": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Description": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "CurrencyCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Breakdown": {
+                "items": {
+                  "properties": {
+                    "Date": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ExcludedTaxAmount": {
+                      "type": [
+                        "null",
+                        "number"
+                      ]
+                    },
+                    "IncludedTaxAmount": {
+                      "type": [
+                        "null",
+                        "number"
+                      ]
+                    },
+                    "TaxAmount": {
+                      "type": [
+                        "null",
+                        "number"
+                      ]
+                    },
+                    "Amount": {
+                      "type": [
+                        "null",
+                        "number"
+                      ]
+                    },
+                    "RateMode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Quantity": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "TaxIncluded": {
+                "type": "boolean"
+              },
+              "TotalPrice": {
+                "type": [
+                  "null",
+                  "number"
+                ]
+              },
+              "TotalTaxAmount": {
+                "type": [
+                  "null",
+                  "number"
+                ]
+              },
+              "TotalExtraTaxAmount": {
+                "type": [
+                  "null",
+                  "number"
+                ]
+              },
+              "CancellationPolicyCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "GuaranteeCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "MarketCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "FullStayWithTaxAndAdditionals": {
+                "type": [
+                  "null",
+                  "number"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "Agency": {
+            "properties": {
+              "Id": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "Name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "EmailAddress": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Comments": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "VatNumber": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "HotelCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Fax": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "CreatedDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "LastUpdateDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Addresses": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "City": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HouseNumber": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "State": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Street": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ZipCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CountryCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LanguageCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "PhoneNumbers": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CountryAccessCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Number": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "ExternalReferences": {
+                "items": {
+                  "properties": {
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SystemCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Attributes": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "StartDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "EndDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "Company": {
+            "properties": {
+              "Id": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "Name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "EmailAddress": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Comments": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "VatNumber": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "HotelCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Fax": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "CreatedDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "LastUpdateDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Addresses": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "City": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HouseNumber": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "State": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Street": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ZipCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CountryCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LanguageCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "PhoneNumbers": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CountryAccessCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Number": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "ExternalReferences": {
+                "items": {
+                  "properties": {
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SystemCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Attributes": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "StartDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "EndDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "SourceCompany": {
+            "properties": {
+              "Id": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "Name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "EmailAddress": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Comments": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "VatNumber": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "HotelCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Fax": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "CreatedDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "LastUpdateDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Addresses": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "City": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HouseNumber": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "State": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Street": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ZipCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CountryCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LanguageCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "PhoneNumbers": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CountryAccessCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Number": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "ExternalReferences": {
+                "items": {
+                  "properties": {
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SystemCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Attributes": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "StartDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "EndDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "ExtraServices": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "Code": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Name": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CurrencyCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "GroupTypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Breakdown": {
+                  "items": {
+                    "properties": {
+                      "Date": {
+                        "format": "date-time",
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "ExcludedTaxAmount": {
+                        "type": [
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "IncludedTaxAmount": {
+                        "type": [
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "TaxAmount": {
+                        "type": [
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "Amount": {
+                        "type": [
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "RateMode": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "Quantity": {
+                        "type": [
+                          "null",
+                          "integer"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "type": [
+                    "null",
+                    "array"
+                  ]
+                },
+                "TaxIncluded": {
+                  "type": "boolean"
+                },
+                "TotalPrice": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "TotalTaxAmount": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "RateMode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Frequency": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Quantity": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "Preferences": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "PersonId": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "ReservationId": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "Code": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Value": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "TypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Source": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "HotelCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "ExternalReferences": {
+            "items": {
+              "properties": {
+                "Code": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "TypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "SystemCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "OtherLinkedPersons": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "RelationType": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "RelationTypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "ExternalSystemCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Person": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Title": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Names": {
+                      "items": {
+                        "properties": {
+                          "Title": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "FirstName": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastName": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Primary": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "EmailAddresses": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "Type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Value": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Verified": {
+                            "type": "boolean"
+                          },
+                          "Source": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "IsPrimary": {
+                            "type": "boolean"
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "LanguageCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CountryCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Gender": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "DateOfBirth": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HotelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "JobTitle": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsMember": {
+                      "type": "boolean"
+                    },
+                    "NewsletterSubscription": {
+                      "type": "boolean"
+                    },
+                    "Company": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "Name": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "EmailAddress": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Comments": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "VatNumber": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "HotelCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Fax": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Addresses": {
+                            "items": {
+                              "properties": {
+                                "Id": {
+                                  "type": [
+                                    "null",
+                                    "integer"
+                                  ]
+                                },
+                                "City": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "HouseNumber": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "State": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "Street": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "ZipCode": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "CountryCode": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "LanguageCode": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "Source": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "Type": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "IsPrimary": {
+                                  "type": "boolean"
+                                },
+                                "CreatedDateTime": {
+                                  "format": "date-time",
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "LastUpdateDateTime": {
+                                  "format": "date-time",
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                              },
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "type": [
+                              "null",
+                              "array"
+                            ]
+                          },
+                          "PhoneNumbers": {
+                            "items": {
+                              "properties": {
+                                "Id": {
+                                  "type": [
+                                    "null",
+                                    "integer"
+                                  ]
+                                },
+                                "CountryAccessCode": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "Number": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "IsPrimary": {
+                                  "type": "boolean"
+                                },
+                                "Source": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "Type": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "CreatedDateTime": {
+                                  "format": "date-time",
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "LastUpdateDateTime": {
+                                  "format": "date-time",
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                              },
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "type": [
+                              "null",
+                              "array"
+                            ]
+                          },
+                          "ExternalReferences": {
+                            "items": {
+                              "properties": {
+                                "Code": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "TypeCode": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "SystemCode": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                              },
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "type": [
+                              "null",
+                              "array"
+                            ]
+                          },
+                          "Attributes": {
+                            "items": {
+                              "properties": {
+                                "Id": {
+                                  "type": [
+                                    "null",
+                                    "integer"
+                                  ]
+                                },
+                                "Code": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "Value": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "TypeCode": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "StartDateTime": {
+                                  "format": "date-time",
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "EndDateTime": {
+                                  "format": "date-time",
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "CreateDateTime": {
+                                  "format": "date-time",
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "LastUpdateDateTime": {
+                                  "format": "date-time",
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                              },
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "type": [
+                              "null",
+                              "array"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "CompanyName": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ExternalReferences": {
+                      "items": {
+                        "properties": {
+                          "Code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "TypeCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "SystemCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "Attributes": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "Code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Value": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "TypeCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "StartDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "EndDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CreateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "Addresses": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "City": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "HouseNumber": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "State": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Street": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "ZipCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CountryCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LanguageCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Source": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "IsPrimary": {
+                            "type": "boolean"
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "PhoneNumbers": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "CountryAccessCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Number": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "IsPrimary": {
+                            "type": "boolean"
+                          },
+                          "Source": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "DataConsents": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "Message": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Source": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "SubSource": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Given": {
+                            "type": "boolean"
+                          },
+                          "Type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "ValidUntil": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "PaymentMethods": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "TypeCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Name": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Value": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "SubTypeCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "PaymentIntegrationCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "PaymentIntegrationMerchantCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "ExpiryDate": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "Preferences": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "PersonId": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "ReservationId": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "Code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Value": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "TypeCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Source": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "HotelCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "LoyaltyLevels": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "LevelCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Rank": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "ValidFrom": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "ValidUntil": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Source": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "StaySummaries": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "CurrencyCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "HotelCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastStayDate": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "NumberOfNights": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "NumberOfStays": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "StayTotalRevenue": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "StayTotalRevenueEnterprise": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "LastStayUnit": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastStayRevenue": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "Documents": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "PersonId": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "HotelCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Source": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Number": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Nationality": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "IssueCity": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "IssueCountry": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "PlaceOfBirth": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "ExpiryDate": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "IssueDate": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "IsPrimary": {
+                            "type": "boolean"
+                          },
+                          "LastChangedBySystem": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "GlobalStays": {
+                      "properties": {
+                        "CurrencyCode": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "LastStayDate": {
+                          "format": "date-time",
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "NumberOfNights": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        },
+                        "NumberOfStays": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        },
+                        "StayTotalRevenue": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        },
+                        "LastStayUnit": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "LastStayHotelCode": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "HotelDiversity": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        }
+                      },
+                      "type": [
+                        "null",
+                        "object"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "LastChangedBySystem": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "Contacts": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "Title": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "FirstName": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastName": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "EmailAddress": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "PhoneNumber": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CompanyName": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Street": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "HouseNumber": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "City": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "State": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "ZipCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CountryCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastChangedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "CreatedDateTime": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "LastChangedDateTime": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "BookingDateTime": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "CancellationDateTime": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "PaymentInformations": {
+            "items": {
+              "properties": {
+                "Amount": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CurrencyCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "RequestedCurrencyCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "AmountInRequestedCurrencyCode": {
+                  "type": [
+                    "null",
+                    "number"
+                  ]
+                },
+                "DueAmount": {
+                  "type": [
+                    "null",
+                    "number"
+                  ]
+                },
+                "Messages": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Method": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "PaymentToken": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "PspPaymentReference": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "ShopperReference": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "MerchantReference": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "ShopperEmailAddress": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "PaymentSource": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CardExpMonth": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "CardExpYear": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "CardDigits": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CardScheme": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "OverrodeByMerchantReference": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "TransactionCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "PaymentMethods": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "TypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Code": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Name": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Value": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "SubTypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "PaymentIntegrationCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "PaymentIntegrationMerchantCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "ExpiryDate": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "Attributes": {
+            "items": {
+              "properties": {
+                "Id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "Code": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "Value": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "TypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "StartDate": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "EndDate": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "CreatedDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "LastUpdateDateTime": {
+                  "format": "date-time",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "SharerReservationId": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      },
+      "stream": "reservation",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "id"
+            ],
+            "forced-replication-method": "INCREMENTAL",
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "ArrivalDate"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "DepartureDate"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "HotelCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "UnitCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "UnitTypeCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "RequestedUnitTypeCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Status"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "NumberOfPersons"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "NumberOfChildren"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "NumberOfInfants"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "NumberOfUnits"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "NumberOfNights"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Comments"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Source"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "SubSource"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "GroupCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "GuaranteeTypeCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "MarketCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "PromoCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "ActualArrivalDate"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "ActualDepartureDate"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Booker"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "PrimaryGuest"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "RatePlan"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Agency"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Company"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "SourceCompany"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "ExtraServices"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Preferences"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "ExternalReferences"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "OtherLinkedPersons"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Contacts"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "CreatedDateTime"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "LastChangedDateTime"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "BookingDateTime"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "CancellationDateTime"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "PaymentInformations"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "PaymentMethods"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Attributes"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "SharerReservationId"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ]
+    },
+    {
+      "tap_stream_id": "house_account",
+      "schema": {
+        "properties": {
+          "Id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "CompanyCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "MarketCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Comments": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "SourceCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "VirtualRoomCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "HotelCode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ExternalReferences": {
+            "items": {
+              "properties": {
+                "Code": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "TypeCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "SystemCode": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "ContactPerson": {
+            "properties": {
+              "Id": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "Title": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Names": {
+                "items": {
+                  "properties": {
+                    "Title": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "FirstName": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastName": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Primary": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "EmailAddresses": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Verified": {
+                      "type": "boolean"
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "LanguageCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "CountryCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Gender": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "DateOfBirth": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "HotelCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Source": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "JobTitle": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "IsMember": {
+                "type": "boolean"
+              },
+              "NewsletterSubscription": {
+                "type": "boolean"
+              },
+              "Company": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Name": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "EmailAddress": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Comments": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "VatNumber": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HotelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Fax": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Addresses": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "City": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "HouseNumber": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "State": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Street": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "ZipCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CountryCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LanguageCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Source": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "IsPrimary": {
+                            "type": "boolean"
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "PhoneNumbers": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "CountryAccessCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Number": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "IsPrimary": {
+                            "type": "boolean"
+                          },
+                          "Source": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Type": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CreatedDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "ExternalReferences": {
+                      "items": {
+                        "properties": {
+                          "Code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "TypeCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "SystemCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    },
+                    "Attributes": {
+                      "items": {
+                        "properties": {
+                          "Id": {
+                            "type": [
+                              "null",
+                              "integer"
+                            ]
+                          },
+                          "Code": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "Value": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "TypeCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "StartDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "EndDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "CreateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "LastUpdateDateTime": {
+                            "format": "date-time",
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          }
+                        },
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "type": [
+                        "null",
+                        "array"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "CompanyName": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "ExternalReferences": {
+                "items": {
+                  "properties": {
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SystemCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Attributes": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "StartDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "EndDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Addresses": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "City": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HouseNumber": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "State": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Street": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ZipCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CountryCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LanguageCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "PhoneNumbers": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CountryAccessCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Number": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "DataConsents": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Message": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SubSource": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Given": {
+                      "type": "boolean"
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ValidUntil": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "PaymentMethods": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Name": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SubTypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "PaymentIntegrationCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "PaymentIntegrationMerchantCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ExpiryDate": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Preferences": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "PersonId": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "ReservationId": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HotelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "LoyaltyLevels": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "LevelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Rank": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "ValidFrom": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ValidUntil": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "StaySummaries": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CurrencyCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HotelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastStayDate": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "NumberOfNights": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "NumberOfStays": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "StayTotalRevenue": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "StayTotalRevenueEnterprise": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "LastStayUnit": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastStayRevenue": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Documents": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "PersonId": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "HotelCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Number": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Nationality": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IssueCity": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IssueCountry": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "PlaceOfBirth": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ExpiryDate": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IssueDate": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "LastChangedBySystem": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "GlobalStays": {
+                "properties": {
+                  "CurrencyCode": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "LastStayDate": {
+                    "format": "date-time",
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "NumberOfNights": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "NumberOfStays": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "StayTotalRevenue": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "LastStayUnit": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "LastStayHotelCode": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "HotelDiversity": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  }
+                },
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false
+              },
+              "LastChangedBySystem": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "CreatedDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "LastUpdateDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "PrimaryPerson": {},
+          "Agency": {
+            "properties": {
+              "Id": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "Name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "EmailAddress": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Comments": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "VatNumber": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "HotelCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Fax": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "CreatedDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "LastUpdateDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Addresses": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "City": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HouseNumber": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "State": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Street": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ZipCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CountryCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LanguageCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "PhoneNumbers": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CountryAccessCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Number": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "ExternalReferences": {
+                "items": {
+                  "properties": {
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SystemCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Attributes": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "StartDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "EndDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "Company": {
+            "properties": {
+              "Id": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "Name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "EmailAddress": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Comments": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "VatNumber": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "HotelCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Fax": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "CreatedDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "LastUpdateDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Addresses": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "City": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HouseNumber": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "State": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Street": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ZipCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CountryCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LanguageCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "PhoneNumbers": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CountryAccessCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Number": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "ExternalReferences": {
+                "items": {
+                  "properties": {
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SystemCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Attributes": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "StartDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "EndDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          },
+          "SourceCompany": {
+            "properties": {
+              "Id": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "Name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "EmailAddress": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Comments": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "VatNumber": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "HotelCode": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Fax": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "CreatedDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "LastUpdateDateTime": {
+                "format": "date-time",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "Addresses": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "City": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "HouseNumber": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "State": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Street": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "ZipCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CountryCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LanguageCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "PhoneNumbers": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "CountryAccessCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Number": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "IsPrimary": {
+                      "type": "boolean"
+                    },
+                    "Source": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Type": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreatedDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "ExternalReferences": {
+                "items": {
+                  "properties": {
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "SystemCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              },
+              "Attributes": {
+                "items": {
+                  "properties": {
+                    "Id": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "Code": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "Value": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "TypeCode": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "StartDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "EndDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "CreateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "LastUpdateDateTime": {
+                      "format": "date-time",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false
+      },
+      "stream": "house_account",
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "id"
+            ],
+            "forced-replication-method": "INCREMENTAL",
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Id"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "CompanyCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "MarketCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Comments"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "SourceCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "VirtualRoomCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "HotelCode"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "ExternalReferences"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "ContactPerson"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "PrimaryPerson"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Agency"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Company"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "SourceCompany"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ pytest-mock = "^3.5.1"
 pytest-vcr = "^1.0.2"
 python-dotenv = "^0.15.0"
 vcrpy = "^4.1.1"
+black = "^20.8b1"
 
 [tool.poetry.scripts]
 tap-ireckonu = 'tap_ireckonu:main'

--- a/sample_config.json
+++ b/sample_config.json
@@ -2,7 +2,8 @@
 # API Keys, Client Ids, Etc
 
 {
-  "username": "my_username",
-  "password": "my_password",
-  "start_date": "2017-01-01T00:00:00Z"
+  "USERNAME": "",
+  "PASSWORD": "",
+  "CLIENT_ID": "",
+  "CLIENT_SECRET": ""
 }

--- a/tap_ireckonu/__init__.py
+++ b/tap_ireckonu/__init__.py
@@ -4,7 +4,7 @@ from tap_ireckonu.discovery import discover
 from tap_ireckonu.sync import sync
 
 # Fill in any required config keys from the config.json here
-REQUIRED_CONFIG_KEYS = [...]
+REQUIRED_CONFIG_KEYS = []
 
 LOGGER = singer.get_logger()
 

--- a/tap_ireckonu/__init__.py
+++ b/tap_ireckonu/__init__.py
@@ -4,7 +4,7 @@ from tap_ireckonu.discovery import discover
 from tap_ireckonu.sync import sync
 
 # Fill in any required config keys from the config.json here
-REQUIRED_CONFIG_KEYS = []
+REQUIRED_CONFIG_KEYS = ["USERNAME", "PASSWORD", "CLIENT_ID","CLIENT_SECRET"]
 
 LOGGER = singer.get_logger()
 

--- a/tap_ireckonu/__init__.py
+++ b/tap_ireckonu/__init__.py
@@ -4,7 +4,7 @@ from tap_ireckonu.discovery import discover
 from tap_ireckonu.sync import sync
 
 # Fill in any required config keys from the config.json here
-REQUIRED_CONFIG_KEYS = ["USERNAME", "PASSWORD", "CLIENT_ID","CLIENT_SECRET"]
+REQUIRED_CONFIG_KEYS = ["USERNAME", "PASSWORD", "CLIENT_ID", "CLIENT_SECRET"]
 
 LOGGER = singer.get_logger()
 
@@ -21,5 +21,5 @@ def main():
         sync(args.config, args.state, catalog)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tap_ireckonu/client.py
+++ b/tap_ireckonu/client.py
@@ -11,132 +11,104 @@ class IreckonuClient:
     PERSON_ENDPOINT = "person"
     RESERVATION_ENDPOINT = "reservation"
 
-    def __init__(self, client_id, client_secret):
+    def __init__(self, config):
+        self.config = config
         self._client = requests.Session()
         self._client.headers.update(
             {"Content-Type": "application/json", "Accept": "application/json"}
         )
 
-    def fetch_access_token(self, client_id, api_key):
-        pass
+    def fetch_access_token(self):
+        payload = {
+            'grant_type': 'password',
+            'username': self.config['USERNAME'],
+            'password': self.config['PASSWORD'],
+            'client_id': self.config['CLIENT_ID'],
+            'client_secret': self.config['CLIENT_SECRET'],
+        }
+        token = self._client.get('https://mint-identity-acc.ireckonu.com/oauth2/token', data=payload)
 
-    def fetch_created_bulk_company(
+        self._client.headers.update(
+            {"Authorization": f"Bearer {token.json()['access_token']}"}
+        )
+
+    def fetch_bulk_company(
         self, start_date: str, end_date: str, page: int, page_size: int
     ) -> dict:
         url = f"{self.BASE_URL}/{self.BULK_API}/{self.COMPANY_ENPOINT}"
         payload = {
-            "Criteria": self._created_criteria(start_date, end_date, page, page_size),
+            "Criteria": self._criteria(start_date, end_date, page, page_size),
             "Filters": self.COMPANY_FILTERS,
         }
-        return self._client.post(url, data=payload).json()
+        payload_json = json.dumps(payload)
+        return self._client.post(url, data=payload_json).json()
 
-    def fetch_updated_bulk_company(
-        self, start_date: str, end_date: str, page: int, page_size: int
-    ) -> dict:
-        url = f"{self.BASE_URL}/{self.BULK_API}/{self.COMPANY_ENPOINT}"
-        payload = {
-            "Criteria": self._updated_criteria(start_date, end_date, page, page_size),
-            "Filters": self.COMPANY_FILTERS,
-        }
-        return self._client.post(url, data=payload).json()
 
-    def fetch_created_bulk_folio(
+    def fetch_bulk_folio(
         self, start_date: str, end_date: str, page: int, page_size: int
     ) -> dict:
         url = f"{self.BASE_URL}/{self.BULK_API}/{self.FOLIO_ENDPOINT}"
         payload = {
-            "Criteria": self._created_criteria(start_date, end_date, page, page_size),
+            "Criteria": self._criteria(start_date, end_date, page, page_size),
             "Filters": self.FOLIO_FILTERS,
         }
-        return self._client.post(url, data=payload).json()
+        payload_json = json.dumps(payload)
+        return self._client.post(url, data=payload_json).json()
 
-    def fetch_updated_bulk_folio(
+
+    def fetch_bulk_person(
         self, start_date: str, end_date: str, page: int, page_size: int
     ) -> dict:
-        url = f"{self.BASE_URL}/{self.BULK_API}/{self.FOLIO_ENDPOINT}"
+        url = f"{self.BASE_URL}/{self.BULK_API}/{self.PERSON_ENDPOINT}"
         payload = {
-            "Criteria": self._updated_criteria(start_date, end_date, page, page_size),
-            "Filters": self.FOLIO_FILTERS,
+            "Criteria": self._criteria(start_date, end_date, page, page_size),
+            "Filters": self.PERSON_FILTERS,
         }
-        return self._client.post(url, data=payload).json()
+        payload_json = json.dumps(payload)
+        return self._client.post(url, data=payload_json).json()
 
-    def fetch_created_bulk_house_account(
-        self, start_date: str, end_date: str, page: int, page_size: int
+
+    def fetch_bulk_house_account(
+        self, hotel_code: str, start_date: str, end_date: str, page: int, page_size: int
     ) -> dict:
         url = f"{self.BASE_URL}/{self.BULK_API}/{self.HOUSE_ACCOUNT_ENDPOINT}"
         payload = {
-            "Criteria": self._created_criteria(start_date, end_date, page, page_size),
+            "Criteria": self._hotel_code_criteria(hotel_code, start_date, end_date, page, page_size),
             "Filters": self.HOUSE_ACCOUNT_FILTERS,
         }
-        return self._client.post(url, data=payload).json()
+        payload_json = json.dumps(payload)
+        return self._client.post(url, data=payload_json).json()
 
-    def fetch_updated_bulk_house_account(
-        self, start_date: str, end_date: str, page: int, page_size: int
-    ) -> dict:
-        url = f"{self.BASE_URL}/{self.BULK_API}/{self.HOUSE_ACCOUNT_ENDPOINT}"
-        payload = {
-            "Criteria": self._updated_criteria(start_date, end_date, page, page_size),
-            "Filters": self.HOUSE_ACCOUNT_FILTERS,
-        }
-        return self._client.post(url, data=payload).json()
 
-    def fetch_created_bulk_person(
-        self, start_date: str, end_date: str, page: int, page_size: int
-    ) -> dict:
-        url = f"{self.BASE_URL}/{self.BULK_API}/{self.PERSON_ENDPOINT}"
-        payload = {
-            "Criteria": self._created_criteria(start_date, end_date, page, page_size),
-            "Filters": self.PERSON_FILTERS,
-        }
-        return self._client.post(url, data=payload).json()
-
-    def fetch_updated_bulk_person(
-        self, start_date: str, end_date: str, page: int, page_size: int
-    ) -> dict:
-        url = f"{self.BASE_URL}/{self.BULK_API}/{self.PERSON_ENDPOINT}"
-        payload = {
-            "Criteria": self._updated_criteria(start_date, end_date, page, page_size),
-            "Filters": self.PERSON_FILTERS,
-        }
-        return self._client.post(url, data=payload).json()
-
-    def fetch_created_bulk_reservation(
-        self, start_date: str, end_date: str, page: int, page_size: int
-    ) -> dict:
-        url = f"{self.BASE_URL}/{self.BULK_API}/{self.PERSON_ENDPOINT}"
-        payload = {
-            "Criteria": self._created_criteria(start_date, end_date, page, page_size),
-            "Filters": self.RESERVATION_FILTERS,
-        }
-        return self._client.post(url, data=payload).json()
-
-    def fetch_updated_bulk_reservation(
-        self, start_date: str, end_date: str, page: int, page_size: int
+    def fetch_bulk_reservation(
+        self, hotel_code: str, start_date: str, end_date: str, page: int, page_size: int
     ) -> dict:
         url = f"{self.BASE_URL}/{self.BULK_API}/{self.RESERVATION_ENDPOINT}"
         payload = {
-            "Criteria": self._updated_criteria(start_date, end_date, page, page_size),
+            "Criteria": self._hotel_code_criteria(hotel_code, start_date, end_date, page, page_size),
             "Filters": self.RESERVATION_FILTERS,
         }
-        return self._client.post(url, data=payload).json()
+        payload_json = json.dumps(payload)
+        return self._client.post(url, data=payload_json).json()
 
     @staticmethod
-    def _created_criteria(
+    def _criteria(
         start_date: str, end_date: str, page: int, page_size: int
     ) -> dict:
         return {
             "Start": start_date,
             "End": end_date,
-            "Type": "Created",
+            "Type": "Updated",
             "Take": page_size,
             "Skip": page * page_size,
         }
 
     @staticmethod
-    def _updated_criteria(
-        start_date: str, end_date: str, page: int, page_size: int
+    def _hotel_code_criteria(
+        hotel_code: str, start_date: str, end_date: str, page: int, page_size: int
     ) -> dict:
         return {
+            "HotelCode": hotel_code,
             "Start": start_date,
             "End": end_date,
             "Type": "Updated",

--- a/tap_ireckonu/client.py
+++ b/tap_ireckonu/client.py
@@ -20,13 +20,15 @@ class IreckonuClient:
 
     def fetch_access_token(self):
         payload = {
-            'grant_type': 'password',
-            'username': self.config['USERNAME'],
-            'password': self.config['PASSWORD'],
-            'client_id': self.config['CLIENT_ID'],
-            'client_secret': self.config['CLIENT_SECRET'],
+            "grant_type": "password",
+            "username": self.config["USERNAME"],
+            "password": self.config["PASSWORD"],
+            "client_id": self.config["CLIENT_ID"],
+            "client_secret": self.config["CLIENT_SECRET"],
         }
-        token = self._client.get('https://mint-identity-acc.ireckonu.com/oauth2/token', data=payload)
+        token = self._client.get(
+            "https://mint-identity-acc.ireckonu.com/oauth2/token", data=payload
+        )
 
         self._client.headers.update(
             {"Authorization": f"Bearer {token.json()['access_token']}"}
@@ -43,7 +45,6 @@ class IreckonuClient:
         payload_json = json.dumps(payload)
         return self._client.post(url, data=payload_json).json()
 
-
     def fetch_bulk_folio(
         self, start_date: str, end_date: str, page: int, page_size: int
     ) -> dict:
@@ -54,7 +55,6 @@ class IreckonuClient:
         }
         payload_json = json.dumps(payload)
         return self._client.post(url, data=payload_json).json()
-
 
     def fetch_bulk_person(
         self, start_date: str, end_date: str, page: int, page_size: int
@@ -67,34 +67,34 @@ class IreckonuClient:
         payload_json = json.dumps(payload)
         return self._client.post(url, data=payload_json).json()
 
-
     def fetch_bulk_house_account(
         self, hotel_code: str, start_date: str, end_date: str, page: int, page_size: int
     ) -> dict:
         url = f"{self.BASE_URL}/{self.BULK_API}/{self.HOUSE_ACCOUNT_ENDPOINT}"
         payload = {
-            "Criteria": self._hotel_code_criteria(hotel_code, start_date, end_date, page, page_size),
+            "Criteria": self._hotel_code_criteria(
+                hotel_code, start_date, end_date, page, page_size
+            ),
             "Filters": self.HOUSE_ACCOUNT_FILTERS,
         }
         payload_json = json.dumps(payload)
         return self._client.post(url, data=payload_json).json()
-
 
     def fetch_bulk_reservation(
         self, hotel_code: str, start_date: str, end_date: str, page: int, page_size: int
     ) -> dict:
         url = f"{self.BASE_URL}/{self.BULK_API}/{self.RESERVATION_ENDPOINT}"
         payload = {
-            "Criteria": self._hotel_code_criteria(hotel_code, start_date, end_date, page, page_size),
+            "Criteria": self._hotel_code_criteria(
+                hotel_code, start_date, end_date, page, page_size
+            ),
             "Filters": self.RESERVATION_FILTERS,
         }
         payload_json = json.dumps(payload)
         return self._client.post(url, data=payload_json).json()
 
     @staticmethod
-    def _criteria(
-        start_date: str, end_date: str, page: int, page_size: int
-    ) -> dict:
+    def _criteria(start_date: str, end_date: str, page: int, page_size: int) -> dict:
         return {
             "Start": start_date,
             "End": end_date,

--- a/tap_ireckonu/client.py
+++ b/tap_ireckonu/client.py
@@ -1,37 +1,348 @@
 import json
 import requests
 
-# Build the Data Resource Service Here as a class with each endpoint as a function.
-# Do not iterate over paginated endpoints in this file.  Below are just samples
 
-class RESOURCENAMEClient:
-    BASE_URL = BASE_API_URL
+class IreckonuClient:
+    BASE_URL = "https://mint-mw-acc.ireckonu.com"
+    BULK_API = "bapi/v1"
+    COMPANY_ENPOINT = "company"
+    FOLIO_ENDPOINT = "folio"
+    HOUSE_ACCOUNT_ENDPOINT = "houseaccount"
+    PERSON_ENDPOINT = "person"
+    RESERVATION_ENDPOINT = "reservation"
 
-    def __init__(self, CLIENT_PARAMETERS):
+    def __init__(self, client_id, client_secret):
         self._client = requests.Session()
-
+        self._client.headers.update(
+            {"Content-Type": "application/json", "Accept": "application/json"}
+        )
 
     def fetch_access_token(self, client_id, api_key):
-        url = f'{self.BASE_URL}/config/api/gettokens'
-        headers = {
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
-        payload_dict = {
-            'client_id': client_id,
-            'apikey': api_key
-        }
-        return self._client.post(url, headers=headers, data=payload_dict).json()['access_token']
+        pass
 
-    def fetch_ENDPOINT_1(self):
-        url = f'{self.BASE_URL}/ADDITIONAL_URI_ADDRESS'
-        param_payload = {
-            'active': 'true',
-            'pagesize': NUMBER,  # Max per page count
-            'page': NUMBER  # Page will have to be iterated over in a range
+    def fetch_created_bulk_company(
+        self, start_date: str, end_date: str, page: int, page_size: int
+    ) -> dict:
+        url = f"{self.BASE_URL}/{self.BULK_API}/{self.COMPANY_ENPOINT}"
+        payload = {
+            "Criteria": self._created_criteria(start_date, end_date, page, page_size),
+            "Filters": self.COMPANY_FILTERS,
         }
-        return self._client.get(url, params=param_payload).json()
+        return self._client.post(url, data=payload).json()
 
-    def fetch_ENDPOINT_2(self):
-        url = f'{self.BASE_URL}/ADDITIONAL_URI_ADDRESS'
-        return self._client.get(url).json()
+    def fetch_updated_bulk_company(
+        self, start_date: str, end_date: str, page: int, page_size: int
+    ) -> dict:
+        url = f"{self.BASE_URL}/{self.BULK_API}/{self.COMPANY_ENPOINT}"
+        payload = {
+            "Criteria": self._updated_criteria(start_date, end_date, page, page_size),
+            "Filters": self.COMPANY_FILTERS,
+        }
+        return self._client.post(url, data=payload).json()
 
+    def fetch_created_bulk_folio(
+        self, start_date: str, end_date: str, page: int, page_size: int
+    ) -> dict:
+        url = f"{self.BASE_URL}/{self.BULK_API}/{self.FOLIO_ENDPOINT}"
+        payload = {
+            "Criteria": self._created_criteria(start_date, end_date, page, page_size),
+            "Filters": self.FOLIO_FILTERS,
+        }
+        return self._client.post(url, data=payload).json()
+
+    def fetch_updated_bulk_folio(
+        self, start_date: str, end_date: str, page: int, page_size: int
+    ) -> dict:
+        url = f"{self.BASE_URL}/{self.BULK_API}/{self.FOLIO_ENDPOINT}"
+        payload = {
+            "Criteria": self._updated_criteria(start_date, end_date, page, page_size),
+            "Filters": self.FOLIO_FILTERS,
+        }
+        return self._client.post(url, data=payload).json()
+
+    def fetch_created_bulk_house_account(
+        self, start_date: str, end_date: str, page: int, page_size: int
+    ) -> dict:
+        url = f"{self.BASE_URL}/{self.BULK_API}/{self.HOUSE_ACCOUNT_ENDPOINT}"
+        payload = {
+            "Criteria": self._created_criteria(start_date, end_date, page, page_size),
+            "Filters": self.HOUSE_ACCOUNT_FILTERS,
+        }
+        return self._client.post(url, data=payload).json()
+
+    def fetch_updated_bulk_house_account(
+        self, start_date: str, end_date: str, page: int, page_size: int
+    ) -> dict:
+        url = f"{self.BASE_URL}/{self.BULK_API}/{self.HOUSE_ACCOUNT_ENDPOINT}"
+        payload = {
+            "Criteria": self._updated_criteria(start_date, end_date, page, page_size),
+            "Filters": self.HOUSE_ACCOUNT_FILTERS,
+        }
+        return self._client.post(url, data=payload).json()
+
+    def fetch_created_bulk_person(
+        self, start_date: str, end_date: str, page: int, page_size: int
+    ) -> dict:
+        url = f"{self.BASE_URL}/{self.BULK_API}/{self.PERSON_ENDPOINT}"
+        payload = {
+            "Criteria": self._created_criteria(start_date, end_date, page, page_size),
+            "Filters": self.PERSON_FILTERS,
+        }
+        return self._client.post(url, data=payload).json()
+
+    def fetch_updated_bulk_person(
+        self, start_date: str, end_date: str, page: int, page_size: int
+    ) -> dict:
+        url = f"{self.BASE_URL}/{self.BULK_API}/{self.PERSON_ENDPOINT}"
+        payload = {
+            "Criteria": self._updated_criteria(start_date, end_date, page, page_size),
+            "Filters": self.PERSON_FILTERS,
+        }
+        return self._client.post(url, data=payload).json()
+
+    def fetch_created_bulk_reservation(
+        self, start_date: str, end_date: str, page: int, page_size: int
+    ) -> dict:
+        url = f"{self.BASE_URL}/{self.BULK_API}/{self.PERSON_ENDPOINT}"
+        payload = {
+            "Criteria": self._created_criteria(start_date, end_date, page, page_size),
+            "Filters": self.RESERVATION_FILTERS,
+        }
+        return self._client.post(url, data=payload).json()
+
+    def fetch_updated_bulk_reservation(
+        self, start_date: str, end_date: str, page: int, page_size: int
+    ) -> dict:
+        url = f"{self.BASE_URL}/{self.BULK_API}/{self.RESERVATION_ENDPOINT}"
+        payload = {
+            "Criteria": self._updated_criteria(start_date, end_date, page, page_size),
+            "Filters": self.RESERVATION_FILTERS,
+        }
+        return self._client.post(url, data=payload).json()
+
+    @staticmethod
+    def _created_criteria(
+        start_date: str, end_date: str, page: int, page_size: int
+    ) -> dict:
+        return {
+            "Start": start_date,
+            "End": end_date,
+            "Type": "Created",
+            "Take": page_size,
+            "Skip": page * page_size,
+        }
+
+    @staticmethod
+    def _updated_criteria(
+        start_date: str, end_date: str, page: int, page_size: int
+    ) -> dict:
+        return {
+            "Start": start_date,
+            "End": end_date,
+            "Type": "Updated",
+            "Take": page_size,
+            "Skip": page * page_size,
+        }
+
+    COMPANY_FILTERS = {
+        "IncludeExternalReferences": True,
+        "IncludeAddresses": True,
+        "IncludePhoneNumbers": True,
+        "IncludeEmailAddresses": True,
+    }
+
+    FOLIO_FILTERS = {"IncludeInvoiceLines": True, "IncludeAddress": True}
+
+    HOUSE_ACCOUNT_FILTERS = {
+        "IncludeExternalReferences": True,
+        "IncludePrimaryPerson": True,
+        "PrimaryPerson": {
+            "IncludeEmailAddresses": True,
+            "IncludeAddresses": True,
+            "IncludePhoneNumbers": True,
+            "IncludeAttributes": True,
+            "IncludeDataConsents": True,
+            "IncludePaymentMethods": True,
+            "IncludeStaySummaries": True,
+            "IncludeDocuments": True,
+            "IncludeGlobalStay": True,
+            "IncludeExternalReferences": True,
+            "IncludeLoyaltyLevels": True,
+            "IncludePreferences": True,
+            "IncludeCompany": True,
+            "Company": {
+                "IncludeExternalReferences": True,
+                "IncludeAddresses": True,
+                "IncludePhoneNumbers": True,
+                "IncludeEmailAddresses": True,
+            },
+        },
+        "IncludeContactPerson": True,
+        "ContactPerson": {
+            "IncludeEmailAddresses": True,
+            "IncludeAddresses": True,
+            "IncludePhoneNumbers": True,
+            "IncludeAttributes": True,
+            "IncludeDataConsents": True,
+            "IncludePaymentMethods": True,
+            "IncludeStaySummaries": True,
+            "IncludeDocuments": True,
+            "IncludeGlobalStay": True,
+            "IncludeExternalReferences": True,
+            "IncludeLoyaltyLevels": True,
+            "IncludePreferences": True,
+            "IncludeCompany": True,
+            "Company": {
+                "IncludeExternalReferences": True,
+                "IncludeAddresses": True,
+                "IncludePhoneNumbers": True,
+                "IncludeEmailAddresses": True,
+            },
+        },
+        "IncludeCompany": True,
+        "Company": {
+            "IncludeExternalReferences": True,
+            "IncludeAddresses": True,
+            "IncludePhoneNumbers": True,
+            "IncludeEmailAddresses": True,
+        },
+        "IncludeAgency": True,
+        "Agency": {
+            "IncludeExternalReferences": True,
+            "IncludeAddresses": True,
+            "IncludePhoneNumbers": True,
+            "IncludeEmailAddresses": True,
+        },
+        "IncludeSourceCompany": True,
+        "SourceCompany": {
+            "IncludeExternalReferences": True,
+            "IncludeAddresses": True,
+            "IncludePhoneNumbers": True,
+            "IncludeEmailAddresses": True,
+        },
+    }
+
+    PERSON_FILTERS = {
+        "IncludeEmailAddresses": True,
+        "IncludeAddresses": True,
+        "IncludePhoneNumbers": True,
+        "IncludeAttributes": True,
+        "IncludeDataConsents": True,
+        "IncludePaymentMethods": True,
+        "IncludeStaySummaries": True,
+        "IncludeDocuments": True,
+        "IncludeGlobalStay": True,
+        "IncludeExternalReferences": True,
+        "IncludeLoyaltyLevels": True,
+        "IncludePreferences": True,
+        "IncludeCompany": True,
+        "Company": {
+            "IncludeExternalReferences": True,
+            "IncludeAddresses": True,
+            "IncludePhoneNumbers": True,
+            "IncludeEmailAddresses": True,
+        },
+    }
+
+    RESERVATION_FILTERS = {
+        "IncludeBooker": True,
+        "Booker": {
+            "IncludeEmailAddresses": True,
+            "IncludeAddresses": True,
+            "IncludePhoneNumbers": True,
+            "IncludeAttributes": True,
+            "IncludeDataConsents": True,
+            "IncludePaymentMethods": True,
+            "IncludeStaySummaries": True,
+            "IncludeDocuments": True,
+            "IncludeGlobalStay": True,
+            "IncludeExternalReferences": True,
+            "IncludeLoyaltyLevels": True,
+            "IncludePreferences": True,
+            "IncludeCompany": True,
+            "Company": {
+                "IncludeExternalReferences": True,
+                "IncludeAddresses": True,
+                "IncludePhoneNumbers": True,
+                "IncludeEmailAddresses": True,
+            },
+        },
+        "IncludePrimaryGuest": True,
+        "PrimaryGuest": {
+            "IncludeEmailAddresses": True,
+            "IncludeAddresses": True,
+            "IncludePhoneNumbers": True,
+            "IncludeAttributes": True,
+            "IncludeDataConsents": True,
+            "IncludePaymentMethods": True,
+            "IncludeStaySummaries": True,
+            "IncludeDocuments": True,
+            "IncludeGlobalStay": True,
+            "IncludeExternalReferences": True,
+            "IncludeLoyaltyLevels": True,
+            "IncludePreferences": True,
+            "IncludeCompany": True,
+            "Company": {
+                "IncludeExternalReferences": True,
+                "IncludeAddresses": True,
+                "IncludePhoneNumbers": True,
+                "IncludeEmailAddresses": True,
+            },
+        },
+        "IncludeOtherLinkedPersons": True,
+        "OtherLinkedPersons": {
+            "IncludeEmailAddresses": True,
+            "IncludeAddresses": True,
+            "IncludePhoneNumbers": True,
+            "IncludeAttributes": True,
+            "IncludeDataConsents": True,
+            "IncludePaymentMethods": True,
+            "IncludeStaySummaries": True,
+            "IncludeDocuments": True,
+            "IncludeGlobalStay": True,
+            "IncludeExternalReferences": True,
+            "IncludeLoyaltyLevels": True,
+            "IncludePreferences": True,
+            "IncludeCompany": True,
+            "Company": {
+                "IncludeExternalReferences": True,
+                "IncludeAddresses": True,
+                "IncludePhoneNumbers": True,
+                "IncludeEmailAddresses": True,
+            },
+        },
+        "IncludeContacts": True,
+        "IncludeRatePlan": True,
+        "IncludeExtraServices": True,
+        "IncludeExternalReferences": True,
+        "IncludePaymentInformations": True,
+        "IncludePaymentMethods": True,
+        "IncludeCompany": True,
+        "IncludeAttributes": True,
+        "IncludePreferences": True,
+        "Company": {
+            "IncludeExternalReferences": True,
+            "IncludeAddresses": True,
+            "IncludePhoneNumbers": True,
+            "IncludeEmailAddresses": True,
+        },
+        "IncludeAgency": True,
+        "Agency": {
+            "IncludeExternalReferences": True,
+            "IncludeAddresses": True,
+            "IncludePhoneNumbers": True,
+            "IncludeEmailAddresses": True,
+        },
+        "IncludeSourceCompany": True,
+        "SourceCompany": {
+            "IncludeExternalReferences": True,
+            "IncludeAddresses": True,
+            "IncludePhoneNumbers": True,
+            "IncludeEmailAddresses": True,
+        },
+        "Extension": {
+            "IncludeRateplans": True,
+            "IncludeExtras": True,
+            "IncludeUnitTypes": True,
+        },
+    }

--- a/tap_ireckonu/discovery.py
+++ b/tap_ireckonu/discovery.py
@@ -16,24 +16,29 @@ def get_schemas():
     schemas_metadata = {}
 
     for stream_name, stream_object in STREAMS.items():
-        schema_path = get_abs_path('schemas/{}.json'.format(stream_name))
+        schema_path = get_abs_path("schemas/{}.json".format(stream_name))
         with open(schema_path) as file:
             schema = json.load(file)
 
         meta = metadata.get_standard_metadata(
             schema=schema,
             key_properties=stream_object.key_properties,
-            replication_method=stream_object.replication_method
+            replication_method=stream_object.replication_method,
         )
 
         meta = metadata.to_map(meta)
 
         if stream_object.valid_replication_keys:
             meta = metadata.write(
-                meta, (), 'valid-replication-keys', stream_object.valid_replication_keys)
+                meta, (), "valid-replication-keys", stream_object.valid_replication_keys
+            )
         if stream_object.replication_key:
             meta = metadata.write(
-                meta, ('properties', stream_object.replication_key), 'inclusion', 'automatic')
+                meta,
+                ("properties", stream_object.replication_key),
+                "inclusion",
+                "automatic",
+            )
 
         meta = metadata.to_list(meta)
 
@@ -51,12 +56,12 @@ def discover():
         schema_meta = schemas_metadata[schema_name]
 
         catalog_entry = {
-            'stream': schema_name,
-            'tap_stream_id': schema_name,
-            'schema': schema,
-            'metadata': schema_meta
+            "stream": schema_name,
+            "tap_stream_id": schema_name,
+            "schema": schema,
+            "metadata": schema_meta,
         }
 
         streams.append(catalog_entry)
 
-    return Catalog.from_dict({'streams': streams})
+    return Catalog.from_dict({"streams": streams})

--- a/tap_ireckonu/schemas/company.json
+++ b/tap_ireckonu/schemas/company.json
@@ -1,0 +1,171 @@
+{
+  "type": ["null", "object"],
+  "additionalProperties": false,
+  "properties": {
+    "Id": {
+      "type": ["null", "integer"]
+    },
+    "Name": {
+      "type": ["null", "string"]
+    },
+    "EmailAddress": {
+      "type": ["null", "string"]
+    },
+    "Comments": {
+      "type": ["null", "string"]
+    },
+    "VatNumber": {
+      "type": ["null", "string"]
+    },
+    "HotelCode": {
+      "type": ["null", "string"]
+    },
+    "Fax": {
+      "type": ["null", "string"]
+    },
+    "CreatedDateTime": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "LastUpdateDateTime": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "Addresses": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "City": {
+            "type": ["null", "string"]
+          },
+          "HouseNumber": {
+            "type": ["null", "string"]
+          },
+          "State": {
+            "type": ["null", "string"]
+          },
+          "Street": {
+            "type": ["null", "string"]
+          },
+          "ZipCode": {
+            "type": ["null", "string"]
+          },
+          "CountryCode": {
+            "type": ["null", "string"]
+          },
+          "LanguageCode": {
+            "type": ["null", "string"]
+          },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "IsPrimary": { "type": "boolean" },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "PhoneNumbers": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "CountryAccessCode": {
+            "type": ["null", "string"]
+          },
+          "Number": {
+            "type": ["null", "string"]
+          },
+          "IsPrimary": { "type": "boolean" },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "ExternalReferences": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "SystemCode": {
+            "type": ["null", "string"]
+          }
+        }
+      }
+    },
+    "Attributes": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "Value": {
+            "type": ["null", "string"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "StartDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "EndDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "CreateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tap_ireckonu/schemas/folio.json
+++ b/tap_ireckonu/schemas/folio.json
@@ -1,0 +1,150 @@
+{
+  "type": ["null", "object"],
+  "additionalProperties": false,
+  "properties": {
+    "Id": {
+      "type": ["null", "integer"]
+    },
+    "HotelCode": {
+      "type": ["null", "string"]
+    },
+    "ReservationId": {
+      "type": ["null", "integer"]
+    },
+    "Total": {
+      "type": ["null", "number"]
+    },
+    "VatTotal": {
+      "type": ["null", "number"]
+    },
+    "InvoiceNumber": {
+      "type": ["null", "string"]
+    },
+    "AdditionalInvoiceNumber": {
+      "type": ["null", "string"]
+    },
+    "PrimaryPersonId": {
+      "type": ["null", "integer"]
+    },
+    "AgencyId": {
+      "type": ["null", "integer"]
+    },
+    "CompanyId": {
+      "type": ["null", "integer"]
+    },
+    "SourceCompanyId": {
+      "type": ["null", "integer"]
+    },
+    "System": {
+      "type": ["null", "string"]
+    },
+    "Status": {
+      "type": ["null", "string"]
+    },
+    "Addresses": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "City": {
+            "type": ["null", "string"]
+          },
+          "HouseNumber": {
+            "type": ["null", "string"]
+          },
+          "State": {
+            "type": ["null", "string"]
+          },
+          "Street": {
+            "type": ["null", "string"]
+          },
+          "ZipCode": {
+            "type": ["null", "string"]
+          },
+          "CountryCode": {
+            "type": ["null", "string"]
+          },
+          "LanguageCode": {
+            "type": ["null", "string"]
+          },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "IsPrimary": { "type": "boolean" },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "Lines": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "InvoiceLineCode": {
+            "type": ["null", "string"]
+          },
+          "Description": {
+            "type": ["null", "string"]
+          },
+          "Quantity": {
+            "type": ["null", "integer"]
+          },
+          "ArticleGroupCode": {
+            "type": ["null", "string"]
+          },
+          "BillingGroupCode": {
+            "type": ["null", "string"]
+          },
+          "Total": {
+            "type": ["null", "number"]
+          },
+          "VatTotal": {
+            "type": ["null", "number"]
+          },
+          "PostingDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "CustomReference": {
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "type": ["null", "string"]
+          },
+          "IsDeleted": { "type": "boolean" },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastChangedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "CreatedDateTime": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "LastChangedDateTime": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
+  }
+}

--- a/tap_ireckonu/schemas/house_account.json
+++ b/tap_ireckonu/schemas/house_account.json
@@ -1,0 +1,1833 @@
+{
+  "type": ["null", "object"],
+  "additionalProperties": false,
+  "properties": {
+    "Id": {
+      "type": ["null", "integer"]
+    },
+    "CompanyCode": {
+      "type": ["null", "string"]
+    },
+    "MarketCode": {
+      "type": ["null", "string"]
+    },
+    "Name": {
+      "type": ["null", "string"]
+    },
+    "Comments": {
+      "type": ["null", "string"]
+    },
+    "SourceCode": {
+      "type": ["null", "string"]
+    },
+    "VirtualRoomCode": {
+      "type": ["null", "string"]
+    },
+    "HotelCode": {
+      "type": ["null", "string"]
+    },
+    "ExternalReferences": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "SystemCode": {
+            "type": ["null", "string"]
+          }
+        }
+      }
+    },
+    "ContactPerson": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "Id": {
+          "type": ["null", "integer"]
+        },
+        "Title": {
+          "type": ["null", "string"]
+        },
+        "Names": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Title": {
+                "type": ["null", "string"]
+              },
+              "FirstName": {
+                "type": ["null", "string"]
+              },
+              "LastName": {
+                "type": ["null", "string"]
+              },
+              "Primary": { "type": "boolean" }
+            }
+          }
+        },
+        "EmailAddresses": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "Verified": { "type": "boolean" },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "LanguageCode": {
+          "type": ["null", "string"]
+        },
+        "CountryCode": {
+          "type": ["null", "string"]
+        },
+        "Gender": {
+          "type": ["null", "string"]
+        },
+        "DateOfBirth": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "HotelCode": {
+          "type": ["null", "string"]
+        },
+        "Source": {
+          "type": ["null", "string"]
+        },
+        "JobTitle": {
+          "type": ["null", "string"]
+        },
+        "IsMember": { "type": "boolean" },
+        "NewsletterSubscription": { "type": "boolean" },
+        "Company": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Name": {
+                "type": ["null", "string"]
+              },
+              "EmailAddress": {
+                "type": ["null", "string"]
+              },
+              "Comments": {
+                "type": ["null", "string"]
+              },
+              "VatNumber": {
+                "type": ["null", "string"]
+              },
+              "HotelCode": {
+                "type": ["null", "string"]
+              },
+              "Fax": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "Addresses": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "City": {
+                      "type": ["null", "string"]
+                    },
+                    "HouseNumber": {
+                      "type": ["null", "string"]
+                    },
+                    "State": {
+                      "type": ["null", "string"]
+                    },
+                    "Street": {
+                      "type": ["null", "string"]
+                    },
+                    "ZipCode": {
+                      "type": ["null", "string"]
+                    },
+                    "CountryCode": {
+                      "type": ["null", "string"]
+                    },
+                    "LanguageCode": {
+                      "type": ["null", "string"]
+                    },
+                    "Source": {
+                      "type": ["null", "string"]
+                    },
+                    "Type": {
+                      "type": ["null", "string"]
+                    },
+                    "IsPrimary": { "type": "boolean" },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "PhoneNumbers": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "CountryAccessCode": {
+                      "type": ["null", "string"]
+                    },
+                    "Number": {
+                      "type": ["null", "string"]
+                    },
+                    "IsPrimary": { "type": "boolean" },
+                    "Source": {
+                      "type": ["null", "string"]
+                    },
+                    "Type": {
+                      "type": ["null", "string"]
+                    },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "ExternalReferences": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Code": {
+                      "type": ["null", "string"]
+                    },
+                    "TypeCode": {
+                      "type": ["null", "string"]
+                    },
+                    "SystemCode": {
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              },
+              "Attributes": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "Code": {
+                      "type": ["null", "string"]
+                    },
+                    "Value": {
+                      "type": ["null", "string"]
+                    },
+                    "TypeCode": {
+                      "type": ["null", "string"]
+                    },
+                    "StartDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "EndDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "CreateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "CompanyName": {
+          "type": ["null", "string"]
+        },
+        "ExternalReferences": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "SystemCode": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        },
+        "Attributes": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "StartDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "EndDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "CreateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "Addresses": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "City": {
+                "type": ["null", "string"]
+              },
+              "HouseNumber": {
+                "type": ["null", "string"]
+              },
+              "State": {
+                "type": ["null", "string"]
+              },
+              "Street": {
+                "type": ["null", "string"]
+              },
+              "ZipCode": {
+                "type": ["null", "string"]
+              },
+              "CountryCode": {
+                "type": ["null", "string"]
+              },
+              "LanguageCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "PhoneNumbers": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "CountryAccessCode": {
+                "type": ["null", "string"]
+              },
+              "Number": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "DataConsents": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Message": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "SubSource": {
+                "type": ["null", "string"]
+              },
+              "Given": { "type": "boolean" },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "ValidUntil": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "PaymentMethods": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Name": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "SubTypeCode": {
+                "type": ["null", "string"]
+              },
+              "PaymentIntegrationCode": {
+                "type": ["null", "string"]
+              },
+              "PaymentIntegrationMerchantCode": {
+                "type": ["null", "string"]
+              },
+              "ExpiryDate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "Preferences": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "PersonId": {
+                "type": ["null", "integer"]
+              },
+              "ReservationId": {
+                "type": ["null", "integer"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "HotelCode": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "LoyaltyLevels": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "LevelCode": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "Rank": {
+                "type": ["null", "integer"]
+              },
+              "ValidFrom": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "ValidUntil": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "StaySummaries": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "CurrencyCode": {
+                "type": ["null", "string"]
+              },
+              "HotelCode": {
+                "type": ["null", "string"]
+              },
+              "LastStayDate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "NumberOfNights": {
+                "type": ["null", "integer"]
+              },
+              "NumberOfStays": {
+                "type": ["null", "integer"]
+              },
+              "StayTotalRevenue": {
+                "type": ["null", "integer"]
+              },
+              "StayTotalRevenueEnterprise": {
+                "type": ["null", "integer"]
+              },
+              "LastStayUnit": {
+                "type": ["null", "string"]
+              },
+              "LastStayRevenue": {
+                "type": ["null", "integer"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "Documents": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "PersonId": {
+                "type": ["null", "integer"]
+              },
+              "HotelCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Number": {
+                "type": ["null", "string"]
+              },
+              "Nationality": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "IssueCity": {
+                "type": ["null", "string"]
+              },
+              "IssueCountry": {
+                "type": ["null", "string"]
+              },
+              "PlaceOfBirth": {
+                "type": ["null", "string"]
+              },
+              "ExpiryDate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "IssueDate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "IsPrimary": { "type": "boolean" },
+              "LastChangedBySystem": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "GlobalStays": {
+          "type": ["null", "object"],
+          "additionalProperties": false,
+          "properties": {
+            "CurrencyCode": {
+              "type": ["null", "string"]
+            },
+            "LastStayDate": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            },
+            "NumberOfNights": {
+              "type": ["null", "integer"]
+            },
+            "NumberOfStays": {
+              "type": ["null", "integer"]
+            },
+            "StayTotalRevenue": {
+              "type": ["null", "integer"]
+            },
+            "LastStayUnit": {
+              "type": ["null", "string"]
+            },
+            "LastStayHotelCode": {
+              "type": ["null", "string"]
+            },
+            "HotelDiversity": {
+              "type": ["null", "integer"]
+            }
+          }
+        },
+        "LastChangedBySystem": {
+          "type": ["null", "string"]
+        },
+        "CreatedDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "LastUpdateDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        }
+      }
+    },
+    "PrimaryPerson": {
+      "Id": {
+        "type": ["null", "integer"]
+      },
+      "Title": {
+        "type": ["null", "string"]
+      },
+      "Names": [
+        {
+          "Title": {
+            "type": ["null", "string"]
+          },
+          "FirstName": {
+            "type": ["null", "string"]
+          },
+          "LastName": {
+            "type": ["null", "string"]
+          },
+          "Primary": { "type": "boolean" }
+        }
+      ],
+      "EmailAddresses": [
+        {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "Value": {
+            "type": ["null", "string"]
+          },
+          "Verified": { "type": "boolean" },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "IsPrimary": { "type": "boolean" },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      ],
+      "LanguageCode": {
+        "type": ["null", "string"]
+      },
+      "CountryCode": {
+        "type": ["null", "string"]
+      },
+      "Gender": {
+        "type": ["null", "string"]
+      },
+      "DateOfBirth": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      },
+      "HotelCode": {
+        "type": ["null", "string"]
+      },
+      "Source": {
+        "type": ["null", "string"]
+      },
+      "JobTitle": {
+        "type": ["null", "string"]
+      },
+      "IsMember": { "type": "boolean" },
+      "NewsletterSubscription": { "type": "boolean" },
+      "Company": {
+        "Id": {
+          "type": ["null", "integer"]
+        },
+        "Name": {
+          "type": ["null", "string"]
+        },
+        "EmailAddress": {
+          "type": ["null", "string"]
+        },
+        "Comments": {
+          "type": ["null", "string"]
+        },
+        "VatNumber": {
+          "type": ["null", "string"]
+        },
+        "HotelCode": {
+          "type": ["null", "string"]
+        },
+        "Fax": {
+          "type": ["null", "string"]
+        },
+        "CreatedDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "LastUpdateDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "Addresses": [
+          {
+            "Id": {
+              "type": ["null", "integer"]
+            },
+            "City": {
+              "type": ["null", "string"]
+            },
+            "HouseNumber": {
+              "type": ["null", "string"]
+            },
+            "State": {
+              "type": ["null", "string"]
+            },
+            "Street": {
+              "type": ["null", "string"]
+            },
+            "ZipCode": {
+              "type": ["null", "string"]
+            },
+            "CountryCode": {
+              "type": ["null", "string"]
+            },
+            "LanguageCode": {
+              "type": ["null", "string"]
+            },
+            "Source": {
+              "type": ["null", "string"]
+            },
+            "Type": {
+              "type": ["null", "string"]
+            },
+            "IsPrimary": { "type": "boolean" },
+            "CreatedDateTime": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            },
+            "LastUpdateDateTime": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            }
+          }
+        ],
+        "PhoneNumbers": [
+          {
+            "Id": {
+              "type": ["null", "integer"]
+            },
+            "CountryAccessCode": {
+              "type": ["null", "string"]
+            },
+            "Number": {
+              "type": ["null", "string"]
+            },
+            "IsPrimary": { "type": "boolean" },
+            "Source": {
+              "type": ["null", "string"]
+            },
+            "Type": {
+              "type": ["null", "string"]
+            },
+            "CreatedDateTime": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            },
+            "LastUpdateDateTime": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            }
+          }
+        ],
+        "ExternalReferences": [
+          {
+            "Code": {
+              "type": ["null", "string"]
+            },
+            "TypeCode": {
+              "type": ["null", "string"]
+            },
+            "SystemCode": {
+              "type": ["null", "string"]
+            }
+          }
+        ],
+        "Attribues": [
+          {
+            "Id": {
+              "type": ["null", "integer"]
+            },
+            "Code": {
+              "type": ["null", "string"]
+            },
+            "Value": {
+              "type": ["null", "string"]
+            },
+            "TypeCode": {
+              "type": ["null", "string"]
+            },
+            "StartDateTime": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            },
+            "EndDateTime": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            },
+            "CreateDateTime": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            },
+            "LastUpdateDateTime": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            }
+          }
+        ]
+      },
+      "CompanyName": {
+        "type": ["null", "string"]
+      },
+      "ExternalReferences": [
+        {
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "SystemCode": {
+            "type": ["null", "string"]
+          }
+        }
+      ],
+      "Attributes": [
+        {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "Value": {
+            "type": ["null", "string"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "HotelCode": {
+            "type": ["null", "string"]
+          },
+          "StartDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "EndDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      ],
+      "Addresses": [
+        {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "City": {
+            "type": ["null", "string"]
+          },
+          "HouseNumber": {
+            "type": ["null", "string"]
+          },
+          "State": {
+            "type": ["null", "string"]
+          },
+          "Street": {
+            "type": ["null", "string"]
+          },
+          "ZipCode": {
+            "type": ["null", "string"]
+          },
+          "CountryCode": {
+            "type": ["null", "string"]
+          },
+          "LanguageCode": {
+            "type": ["null", "string"]
+          },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "IsPrimary": { "type": "boolean" },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      ],
+      "PhoneNumbers": [
+        {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "CountryAccessCode": {
+            "type": ["null", "string"]
+          },
+          "Number": {
+            "type": ["null", "string"]
+          },
+          "IsPrimary": { "type": "boolean" },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      ],
+      "DataConsents": [
+        {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "Message": {
+            "type": ["null", "string"]
+          },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "SubSource": {
+            "type": ["null", "string"]
+          },
+          "Given": { "type": "boolean" },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "ValidUntil": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      ],
+      "PaymentMethods": [
+        {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "Name": {
+            "type": ["null", "string"]
+          },
+          "Value": {
+            "type": ["null", "string"]
+          },
+          "SubTypeCode": {
+            "type": ["null", "string"]
+          },
+          "PaymentIntegrationCode": {
+            "type": ["null", "string"]
+          },
+          "PaymentIntegrationMerchantCode": {
+            "type": ["null", "string"]
+          },
+          "ExpiryDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      ],
+      "Preferences": [
+        {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "PersonId": 0,
+          "ReservationId": 0,
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "Value": {
+            "type": ["null", "string"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "HotelCode": {
+            "type": ["null", "string"]
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      ],
+      "LoyaltyLevels": [
+        {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "LevelCode": {
+            "type": ["null", "string"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "Rank": 0,
+          "ValidFrom": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "ValidUntil": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      ],
+      "StaySummaries": [
+        {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "CurrencyCode": {
+            "type": ["null", "string"]
+          },
+          "HotelCode": {
+            "type": ["null", "string"]
+          },
+          "LastStayDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "NumberOfNights": 0,
+          "NumberOfStays": 0,
+          "StayTotalRevenue": 0,
+          "StayTotalRevenueEnterprise": 0,
+          "LastStayUnit": {
+            "type": ["null", "string"]
+          },
+          "LastStayRevenue": 0,
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      ],
+      "Documents": [
+        {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "PersonId": 0,
+          "HotelCode": {
+            "type": ["null", "string"]
+          },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "Number": {
+            "type": ["null", "string"]
+          },
+          "Nationality": {
+            "type": ["null", "string"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "IssueCity": {
+            "type": ["null", "string"]
+          },
+          "IssueCountry": {
+            "type": ["null", "string"]
+          },
+          "PlaceOfBirth": {
+            "type": ["null", "string"]
+          },
+          "ExpiryDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "IssueDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "IsPrimary": { "type": "boolean" },
+          "LastChangedBySystem": {
+            "type": ["null", "string"]
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      ],
+      "GlobalStay": {
+        "CurrencyCode": {
+          "type": ["null", "string"]
+        },
+        "LastStayDate": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "NumberOfNights": 0,
+        "NumberOfStays": 0,
+        "StayTotalRevenue": 0,
+        "LastStayUnit": {
+          "type": ["null", "string"]
+        },
+        "LastStayHotelCode": {
+          "type": ["null", "string"]
+        },
+        "HotelDiversity": 0
+      },
+      "LastChangedBySystem": {
+        "type": ["null", "string"]
+      },
+      "CreatedDateTime": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      },
+      "LastUpdateDateTime": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      }
+    },
+    "Agency": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "Id": {
+          "type": ["null", "integer"]
+        },
+        "Name": {
+          "type": ["null", "string"]
+        },
+        "EmailAddress": {
+          "type": ["null", "string"]
+        },
+        "Comments": {
+          "type": ["null", "string"]
+        },
+        "VatNumber": {
+          "type": ["null", "string"]
+        },
+        "HotelCode": {
+          "type": ["null", "string"]
+        },
+        "Fax": {
+          "type": ["null", "string"]
+        },
+        "CreatedDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "LastUpdateDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "Addresses": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "City": {
+                "type": ["null", "string"]
+              },
+              "HouseNumber": {
+                "type": ["null", "string"]
+              },
+              "State": {
+                "type": ["null", "string"]
+              },
+              "Street": {
+                "type": ["null", "string"]
+              },
+              "ZipCode": {
+                "type": ["null", "string"]
+              },
+              "CountryCode": {
+                "type": ["null", "string"]
+              },
+              "LanguageCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "PhoneNumbers": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "CountryAccessCode": {
+                "type": ["null", "string"]
+              },
+              "Number": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "ExternalReferences": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "SystemCode": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        },
+        "Attributes": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "StartDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "EndDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "CreateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        }
+      }
+    },
+    "Company": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "Id": {
+          "type": ["null", "integer"]
+        },
+        "Name": {
+          "type": ["null", "string"]
+        },
+        "EmailAddress": {
+          "type": ["null", "string"]
+        },
+        "Comments": {
+          "type": ["null", "string"]
+        },
+        "VatNumber": {
+          "type": ["null", "string"]
+        },
+        "HotelCode": {
+          "type": ["null", "string"]
+        },
+        "Fax": {
+          "type": ["null", "string"]
+        },
+        "CreatedDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "LastUpdateDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "Addresses": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "City": {
+                "type": ["null", "string"]
+              },
+              "HouseNumber": {
+                "type": ["null", "string"]
+              },
+              "State": {
+                "type": ["null", "string"]
+              },
+              "Street": {
+                "type": ["null", "string"]
+              },
+              "ZipCode": {
+                "type": ["null", "string"]
+              },
+              "CountryCode": {
+                "type": ["null", "string"]
+              },
+              "LanguageCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "PhoneNumbers": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "CountryAccessCode": {
+                "type": ["null", "string"]
+              },
+              "Number": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "ExternalReferences": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "SystemCode": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        },
+        "Attributes": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "StartDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "EndDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "CreateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        }
+      }
+    },
+    "SourceCompany": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "Id": {
+          "type": ["null", "integer"]
+        },
+        "Name": {
+          "type": ["null", "string"]
+        },
+        "EmailAddress": {
+          "type": ["null", "string"]
+        },
+        "Comments": {
+          "type": ["null", "string"]
+        },
+        "VatNumber": {
+          "type": ["null", "string"]
+        },
+        "HotelCode": {
+          "type": ["null", "string"]
+        },
+        "Fax": {
+          "type": ["null", "string"]
+        },
+        "CreatedDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "LastUpdateDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "Addresses": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "City": {
+                "type": ["null", "string"]
+              },
+              "HouseNumber": {
+                "type": ["null", "string"]
+              },
+              "State": {
+                "type": ["null", "string"]
+              },
+              "Street": {
+                "type": ["null", "string"]
+              },
+              "ZipCode": {
+                "type": ["null", "string"]
+              },
+              "CountryCode": {
+                "type": ["null", "string"]
+              },
+              "LanguageCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "PhoneNumbers": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "CountryAccessCode": {
+                "type": ["null", "string"]
+              },
+              "Number": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "ExternalReferences": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "SystemCode": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        },
+        "Attributes": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "StartDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "EndDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "CreateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tap_ireckonu/schemas/person.json
+++ b/tap_ireckonu/schemas/person.json
@@ -1,0 +1,699 @@
+{
+  "type": ["null", "object"],
+  "additionalProperties": false,
+  "properties": {
+    "Id": {
+      "type": ["null", "integer"]
+    },
+    "Title": {
+      "type": ["null", "string"]
+    },
+    "Names": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Title": {
+            "type": ["null", "string"]
+          },
+          "FirstName": {
+            "type": ["null", "string"]
+          },
+          "LastName": {
+            "type": ["null", "string"]
+          },
+          "Primary": { "type": "boolean" }
+        }
+      }
+    },
+    "EmailAddresses": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "Value": {
+            "type": ["null", "string"]
+          },
+          "Verified": { "type": "boolean" },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "IsPrimary": { "type": "boolean" },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "LanguageCode": {
+      "type": ["null", "string"]
+    },
+    "CountryCode": {
+      "type": ["null", "string"]
+    },
+    "Gender": {
+      "type": ["null", "string"]
+    },
+    "DateOfBirth": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "HotelCode": {
+      "type": ["null", "string"]
+    },
+    "Source": {
+      "type": ["null", "string"]
+    },
+    "JobTitle": {
+      "type": ["null", "string"]
+    },
+    "IsMember": { "type": "boolean" },
+    "NewsletterSubscription": { "type": "boolean" },
+    "Company": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "Name": {
+            "type": ["null", "string"]
+          },
+          "EmailAddress": {
+            "type": ["null", "string"]
+          },
+          "Comments": {
+            "type": ["null", "string"]
+          },
+          "VatNumber": {
+            "type": ["null", "string"]
+          },
+          "HotelCode": {
+            "type": ["null", "string"]
+          },
+          "Fax": {
+            "type": ["null", "string"]
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "Addresses": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "properties": {
+                "Id": {
+                  "type": ["null", "integer"]
+                },
+                "City": {
+                  "type": ["null", "string"]
+                },
+                "HouseNumber": {
+                  "type": ["null", "string"]
+                },
+                "State": {
+                  "type": ["null", "string"]
+                },
+                "Street": {
+                  "type": ["null", "string"]
+                },
+                "ZipCode": {
+                  "type": ["null", "string"]
+                },
+                "CountryCode": {
+                  "type": ["null", "string"]
+                },
+                "LanguageCode": {
+                  "type": ["null", "string"]
+                },
+                "Source": {
+                  "type": ["null", "string"]
+                },
+                "Type": {
+                  "type": ["null", "string"]
+                },
+                "IsPrimary": { "type": "boolean" },
+                "CreatedDateTime": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "LastUpdateDateTime": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "PhoneNumbers": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "properties": {
+                "Id": {
+                  "type": ["null", "integer"]
+                },
+                "CountryAccessCode": {
+                  "type": ["null", "string"]
+                },
+                "Number": {
+                  "type": ["null", "string"]
+                },
+                "IsPrimary": { "type": "boolean" },
+                "Source": {
+                  "type": ["null", "string"]
+                },
+                "Type": {
+                  "type": ["null", "string"]
+                },
+                "CreatedDateTime": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "LastUpdateDateTime": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "ExternalReferences": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "properties": {
+                "Code": {
+                  "type": ["null", "string"]
+                },
+                "TypeCode": {
+                  "type": ["null", "string"]
+                },
+                "SystemCode": {
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "Attributes": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "properties": {
+                "Id": {
+                  "type": ["null", "integer"]
+                },
+                "Code": {
+                  "type": ["null", "string"]
+                },
+                "Value": {
+                  "type": ["null", "string"]
+                },
+                "TypeCode": {
+                  "type": ["null", "string"]
+                },
+                "StartDateTime": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "EndDateTime": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "CreateDateTime": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "LastUpdateDateTime": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "CompanyName": {
+      "type": ["null", "string"]
+    },
+    "ExternalReferences": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "SystemCode": {
+            "type": ["null", "string"]
+          }
+        }
+      }
+    },
+    "Attributes": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "Value": {
+            "type": ["null", "string"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "StartDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "EndDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "CreateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "Addresses": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "City": {
+            "type": ["null", "string"]
+          },
+          "HouseNumber": {
+            "type": ["null", "string"]
+          },
+          "State": {
+            "type": ["null", "string"]
+          },
+          "Street": {
+            "type": ["null", "string"]
+          },
+          "ZipCode": {
+            "type": ["null", "string"]
+          },
+          "CountryCode": {
+            "type": ["null", "string"]
+          },
+          "LanguageCode": {
+            "type": ["null", "string"]
+          },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "IsPrimary": { "type": "boolean" },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "PhoneNumbers": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "CountryAccessCode": {
+            "type": ["null", "string"]
+          },
+          "Number": {
+            "type": ["null", "string"]
+          },
+          "IsPrimary": { "type": "boolean" },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "DataConsents": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "Message": {
+            "type": ["null", "string"]
+          },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "SubSource": {
+            "type": ["null", "string"]
+          },
+          "Given": { "type": "boolean" },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "ValidUntil": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "PaymentMethods": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "Name": {
+            "type": ["null", "string"]
+          },
+          "Value": {
+            "type": ["null", "string"]
+          },
+          "SubTypeCode": {
+            "type": ["null", "string"]
+          },
+          "PaymentIntegrationCode": {
+            "type": ["null", "string"]
+          },
+          "PaymentIntegrationMerchantCode": {
+            "type": ["null", "string"]
+          },
+          "ExpiryDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "Preferences": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "PersonId": {
+            "type": ["null", "integer"]
+          },
+          "ReservationId": {
+            "type": ["null", "integer"]
+          },
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "Value": {
+            "type": ["null", "string"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "HotelCode": {
+            "type": ["null", "string"]
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "LoyaltyLevels": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "LevelCode": {
+            "type": ["null", "string"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "Rank": {
+            "type": ["null", "integer"]
+          },
+          "ValidFrom": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "ValidUntil": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "StaySummaries": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "CurrencyCode": {
+            "type": ["null", "string"]
+          },
+          "HotelCode": {
+            "type": ["null", "string"]
+          },
+          "LastStayDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "NumberOfNights": {
+            "type": ["null", "integer"]
+          },
+          "NumberOfStays": {
+            "type": ["null", "integer"]
+          },
+          "StayTotalRevenue": {
+            "type": ["null", "integer"]
+          },
+          "StayTotalRevenueEnterprise": {
+            "type": ["null", "integer"]
+          },
+          "LastStayUnit": {
+            "type": ["null", "string"]
+          },
+          "LastStayRevenue": {
+            "type": ["null", "integer"]
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "Documents": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "PersonId": {
+            "type": ["null", "integer"]
+          },
+          "HotelCode": {
+            "type": ["null", "string"]
+          },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "Number": {
+            "type": ["null", "string"]
+          },
+          "Nationality": {
+            "type": ["null", "string"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "IssueCity": {
+            "type": ["null", "string"]
+          },
+          "IssueCountry": {
+            "type": ["null", "string"]
+          },
+          "PlaceOfBirth": {
+            "type": ["null", "string"]
+          },
+          "ExpiryDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "IssueDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "IsPrimary": { "type": "boolean" },
+          "LastChangedBySystem": {
+            "type": ["null", "string"]
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "GlobalStays": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "CurrencyCode": {
+          "type": ["null", "string"]
+        },
+        "LastStayDate": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "NumberOfNights": {
+          "type": ["null", "integer"]
+        },
+        "NumberOfStays": {
+          "type": ["null", "integer"]
+        },
+        "StayTotalRevenue": {
+          "type": ["null", "integer"]
+        },
+        "LastStayUnit": {
+          "type": ["null", "string"]
+        },
+        "LastStayHotelCode": {
+          "type": ["null", "string"]
+        },
+        "HotelDiversity": {
+          "type": ["null", "integer"]
+        }
+      }
+    },
+    "LastChangedBySystem": {
+      "type": ["null", "string"]
+    },
+    "CreatedDateTime": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "LastUpdateDateTime": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
+  }
+}

--- a/tap_ireckonu/schemas/reservation.json
+++ b/tap_ireckonu/schemas/reservation.json
@@ -1,0 +1,3133 @@
+{
+  "type": ["null", "object"],
+  "additionalProperties": false,
+  "properties": {
+    "Id": {
+      "type": ["null", "integer"]
+    },
+    "ArrivalDate": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "DepartureDate": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "HotelCode": {
+      "type": ["null", "string"]
+    },
+    "UnitCode": {
+      "type": ["null", "string"]
+    },
+    "UnitTypeCode": {
+      "type": ["null", "string"]
+    },
+    "RequestedUnitTypeCode": {
+      "type": ["null", "string"]
+    },
+    "Status": {
+      "type": ["null", "string"]
+    },
+    "NumberOfPersons": {
+      "type": ["null", "integer"]
+    },
+    "NumberOfChildren": {
+      "type": ["null", "integer"]
+    },
+    "NumberOfInfants": {
+      "type": ["null", "integer"]
+    },
+    "NumberOfUnits": {
+      "type": ["null", "integer"]
+    },
+    "NumberOfNights": {
+      "type": ["null", "integer"]
+    },
+    "Comments": {
+      "type": ["null", "string"]
+    },
+    "Source": {
+      "type": ["null", "string"]
+    },
+    "SubSource": {
+      "type": ["null", "string"]
+    },
+    "GroupCode": {
+      "type": ["null", "string"]
+    },
+    "GuaranteeTypeCode": {
+      "type": ["null", "string"]
+    },
+    "MarketCode": {
+      "type": ["null", "string"]
+    },
+    "PromoCode": {
+      "type": ["null", "string"]
+    },
+    "ActualArrivalDate": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "ActualDepartureDate": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "Booker": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "Id": {
+          "type": ["null", "integer"]
+        },
+        "Title": {
+          "type": ["null", "string"]
+        },
+        "Names": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Title": {
+                "type": ["null", "string"]
+              },
+              "FirstName": {
+                "type": ["null", "string"]
+              },
+              "LastName": {
+                "type": ["null", "string"]
+              },
+              "Primary": { "type": "boolean" }
+            }
+          }
+        },
+        "EmailAddresses": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "Verified": { "type": "boolean" },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "LanguageCode": {
+          "type": ["null", "string"]
+        },
+        "CountryCode": {
+          "type": ["null", "string"]
+        },
+        "Gender": {
+          "type": ["null", "string"]
+        },
+        "DateOfBirth": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "HotelCode": {
+          "type": ["null", "string"]
+        },
+        "Source": {
+          "type": ["null", "string"]
+        },
+        "JobTitle": {
+          "type": ["null", "string"]
+        },
+        "IsMember": { "type": "boolean" },
+        "NewsletterSubscription": { "type": "boolean" },
+        "Company": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Name": {
+                "type": ["null", "string"]
+              },
+              "EmailAddress": {
+                "type": ["null", "string"]
+              },
+              "Comments": {
+                "type": ["null", "string"]
+              },
+              "VatNumber": {
+                "type": ["null", "string"]
+              },
+              "HotelCode": {
+                "type": ["null", "string"]
+              },
+              "Fax": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "Addresses": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "City": {
+                      "type": ["null", "string"]
+                    },
+                    "HouseNumber": {
+                      "type": ["null", "string"]
+                    },
+                    "State": {
+                      "type": ["null", "string"]
+                    },
+                    "Street": {
+                      "type": ["null", "string"]
+                    },
+                    "ZipCode": {
+                      "type": ["null", "string"]
+                    },
+                    "CountryCode": {
+                      "type": ["null", "string"]
+                    },
+                    "LanguageCode": {
+                      "type": ["null", "string"]
+                    },
+                    "Source": {
+                      "type": ["null", "string"]
+                    },
+                    "Type": {
+                      "type": ["null", "string"]
+                    },
+                    "IsPrimary": { "type": "boolean" },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "PhoneNumbers": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "CountryAccessCode": {
+                      "type": ["null", "string"]
+                    },
+                    "Number": {
+                      "type": ["null", "string"]
+                    },
+                    "IsPrimary": { "type": "boolean" },
+                    "Source": {
+                      "type": ["null", "string"]
+                    },
+                    "Type": {
+                      "type": ["null", "string"]
+                    },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "ExternalReferences": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Code": {
+                      "type": ["null", "string"]
+                    },
+                    "TypeCode": {
+                      "type": ["null", "string"]
+                    },
+                    "SystemCode": {
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              },
+              "Attributes": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "Code": {
+                      "type": ["null", "string"]
+                    },
+                    "Value": {
+                      "type": ["null", "string"]
+                    },
+                    "TypeCode": {
+                      "type": ["null", "string"]
+                    },
+                    "StartDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "EndDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "CreateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "CompanyName": {
+          "type": ["null", "string"]
+        },
+        "ExternalReferences": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "SystemCode": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        },
+        "Attributes": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "StartDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "EndDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "CreateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "Addresses": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "City": {
+                "type": ["null", "string"]
+              },
+              "HouseNumber": {
+                "type": ["null", "string"]
+              },
+              "State": {
+                "type": ["null", "string"]
+              },
+              "Street": {
+                "type": ["null", "string"]
+              },
+              "ZipCode": {
+                "type": ["null", "string"]
+              },
+              "CountryCode": {
+                "type": ["null", "string"]
+              },
+              "LanguageCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "PhoneNumbers": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "CountryAccessCode": {
+                "type": ["null", "string"]
+              },
+              "Number": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "DataConsents": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Message": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "SubSource": {
+                "type": ["null", "string"]
+              },
+              "Given": { "type": "boolean" },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "ValidUntil": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "PaymentMethods": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Name": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "SubTypeCode": {
+                "type": ["null", "string"]
+              },
+              "PaymentIntegrationCode": {
+                "type": ["null", "string"]
+              },
+              "PaymentIntegrationMerchantCode": {
+                "type": ["null", "string"]
+              },
+              "ExpiryDate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "Preferences": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "PersonId": {
+                "type": ["null", "integer"]
+              },
+              "ReservationId": {
+                "type": ["null", "integer"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "HotelCode": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "LoyaltyLevels": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "LevelCode": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "Rank": {
+                "type": ["null", "integer"]
+              },
+              "ValidFrom": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "ValidUntil": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "StaySummaries": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "CurrencyCode": {
+                "type": ["null", "string"]
+              },
+              "HotelCode": {
+                "type": ["null", "string"]
+              },
+              "LastStayDate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "NumberOfNights": {
+                "type": ["null", "integer"]
+              },
+              "NumberOfStays": {
+                "type": ["null", "integer"]
+              },
+              "StayTotalRevenue": {
+                "type": ["null", "integer"]
+              },
+              "StayTotalRevenueEnterprise": {
+                "type": ["null", "integer"]
+              },
+              "LastStayUnit": {
+                "type": ["null", "string"]
+              },
+              "LastStayRevenue": {
+                "type": ["null", "integer"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "Documents": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "PersonId": {
+                "type": ["null", "integer"]
+              },
+              "HotelCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Number": {
+                "type": ["null", "string"]
+              },
+              "Nationality": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "IssueCity": {
+                "type": ["null", "string"]
+              },
+              "IssueCountry": {
+                "type": ["null", "string"]
+              },
+              "PlaceOfBirth": {
+                "type": ["null", "string"]
+              },
+              "ExpiryDate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "IssueDate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "IsPrimary": { "type": "boolean" },
+              "LastChangedBySystem": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "GlobalStays": {
+          "type": ["null", "object"],
+          "additionalProperties": false,
+          "properties": {
+            "CurrencyCode": {
+              "type": ["null", "string"]
+            },
+            "LastStayDate": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            },
+            "NumberOfNights": {
+              "type": ["null", "integer"]
+            },
+            "NumberOfStays": {
+              "type": ["null", "integer"]
+            },
+            "StayTotalRevenue": {
+              "type": ["null", "integer"]
+            },
+            "LastStayUnit": {
+              "type": ["null", "string"]
+            },
+            "LastStayHotelCode": {
+              "type": ["null", "string"]
+            },
+            "HotelDiversity": {
+              "type": ["null", "integer"]
+            }
+          }
+        },
+        "LastChangedBySystem": {
+          "type": ["null", "string"]
+        },
+        "CreatedDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "LastUpdateDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        }
+      }
+    },
+    "PrimaryGuest": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "Id": {
+          "type": ["null", "integer"]
+        },
+        "Title": {
+          "type": ["null", "string"]
+        },
+        "Names": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Title": {
+                "type": ["null", "string"]
+              },
+              "FirstName": {
+                "type": ["null", "string"]
+              },
+              "LastName": {
+                "type": ["null", "string"]
+              },
+              "Primary": { "type": "boolean" }
+            }
+          }
+        },
+        "EmailAddresses": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "Verified": { "type": "boolean" },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "LanguageCode": {
+          "type": ["null", "string"]
+        },
+        "CountryCode": {
+          "type": ["null", "string"]
+        },
+        "Gender": {
+          "type": ["null", "string"]
+        },
+        "DateOfBirth": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "HotelCode": {
+          "type": ["null", "string"]
+        },
+        "Source": {
+          "type": ["null", "string"]
+        },
+        "JobTitle": {
+          "type": ["null", "string"]
+        },
+        "IsMember": { "type": "boolean" },
+        "NewsletterSubscription": { "type": "boolean" },
+        "Company": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Name": {
+                "type": ["null", "string"]
+              },
+              "EmailAddress": {
+                "type": ["null", "string"]
+              },
+              "Comments": {
+                "type": ["null", "string"]
+              },
+              "VatNumber": {
+                "type": ["null", "string"]
+              },
+              "HotelCode": {
+                "type": ["null", "string"]
+              },
+              "Fax": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "Addresses": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "City": {
+                      "type": ["null", "string"]
+                    },
+                    "HouseNumber": {
+                      "type": ["null", "string"]
+                    },
+                    "State": {
+                      "type": ["null", "string"]
+                    },
+                    "Street": {
+                      "type": ["null", "string"]
+                    },
+                    "ZipCode": {
+                      "type": ["null", "string"]
+                    },
+                    "CountryCode": {
+                      "type": ["null", "string"]
+                    },
+                    "LanguageCode": {
+                      "type": ["null", "string"]
+                    },
+                    "Source": {
+                      "type": ["null", "string"]
+                    },
+                    "Type": {
+                      "type": ["null", "string"]
+                    },
+                    "IsPrimary": { "type": "boolean" },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "PhoneNumbers": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "CountryAccessCode": {
+                      "type": ["null", "string"]
+                    },
+                    "Number": {
+                      "type": ["null", "string"]
+                    },
+                    "IsPrimary": { "type": "boolean" },
+                    "Source": {
+                      "type": ["null", "string"]
+                    },
+                    "Type": {
+                      "type": ["null", "string"]
+                    },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "ExternalReferences": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Code": {
+                      "type": ["null", "string"]
+                    },
+                    "TypeCode": {
+                      "type": ["null", "string"]
+                    },
+                    "SystemCode": {
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              },
+              "Attributes": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "Code": {
+                      "type": ["null", "string"]
+                    },
+                    "Value": {
+                      "type": ["null", "string"]
+                    },
+                    "TypeCode": {
+                      "type": ["null", "string"]
+                    },
+                    "StartDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "EndDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "CreateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "CompanyName": {
+          "type": ["null", "string"]
+        },
+        "ExternalReferences": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "SystemCode": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        },
+        "Attributes": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "StartDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "EndDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "CreateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "Addresses": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "City": {
+                "type": ["null", "string"]
+              },
+              "HouseNumber": {
+                "type": ["null", "string"]
+              },
+              "State": {
+                "type": ["null", "string"]
+              },
+              "Street": {
+                "type": ["null", "string"]
+              },
+              "ZipCode": {
+                "type": ["null", "string"]
+              },
+              "CountryCode": {
+                "type": ["null", "string"]
+              },
+              "LanguageCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "PhoneNumbers": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "CountryAccessCode": {
+                "type": ["null", "string"]
+              },
+              "Number": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "DataConsents": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Message": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "SubSource": {
+                "type": ["null", "string"]
+              },
+              "Given": { "type": "boolean" },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "ValidUntil": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "PaymentMethods": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Name": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "SubTypeCode": {
+                "type": ["null", "string"]
+              },
+              "PaymentIntegrationCode": {
+                "type": ["null", "string"]
+              },
+              "PaymentIntegrationMerchantCode": {
+                "type": ["null", "string"]
+              },
+              "ExpiryDate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "Preferences": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "PersonId": {
+                "type": ["null", "integer"]
+              },
+              "ReservationId": {
+                "type": ["null", "integer"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "HotelCode": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "LoyaltyLevels": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "LevelCode": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "Rank": {
+                "type": ["null", "integer"]
+              },
+              "ValidFrom": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "ValidUntil": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "StaySummaries": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "CurrencyCode": {
+                "type": ["null", "string"]
+              },
+              "HotelCode": {
+                "type": ["null", "string"]
+              },
+              "LastStayDate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "NumberOfNights": {
+                "type": ["null", "integer"]
+              },
+              "NumberOfStays": {
+                "type": ["null", "integer"]
+              },
+              "StayTotalRevenue": {
+                "type": ["null", "integer"]
+              },
+              "StayTotalRevenueEnterprise": {
+                "type": ["null", "integer"]
+              },
+              "LastStayUnit": {
+                "type": ["null", "string"]
+              },
+              "LastStayRevenue": {
+                "type": ["null", "integer"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "Documents": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "PersonId": {
+                "type": ["null", "integer"]
+              },
+              "HotelCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Number": {
+                "type": ["null", "string"]
+              },
+              "Nationality": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "IssueCity": {
+                "type": ["null", "string"]
+              },
+              "IssueCountry": {
+                "type": ["null", "string"]
+              },
+              "PlaceOfBirth": {
+                "type": ["null", "string"]
+              },
+              "ExpiryDate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "IssueDate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "IsPrimary": { "type": "boolean" },
+              "LastChangedBySystem": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "GlobalStays": {
+          "type": ["null", "object"],
+          "additionalProperties": false,
+          "properties": {
+            "CurrencyCode": {
+              "type": ["null", "string"]
+            },
+            "LastStayDate": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            },
+            "NumberOfNights": {
+              "type": ["null", "integer"]
+            },
+            "NumberOfStays": {
+              "type": ["null", "integer"]
+            },
+            "StayTotalRevenue": {
+              "type": ["null", "integer"]
+            },
+            "LastStayUnit": {
+              "type": ["null", "string"]
+            },
+            "LastStayHotelCode": {
+              "type": ["null", "string"]
+            },
+            "HotelDiversity": {
+              "type": ["null", "integer"]
+            }
+          }
+        },
+        "LastChangedBySystem": {
+          "type": ["null", "string"]
+        },
+        "CreatedDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "LastUpdateDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        }
+      }
+    },
+    "RatePlan": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "Code": {
+          "type": ["null", "string"]
+        },
+        "Name": {
+          "type": ["null", "string"]
+        },
+        "Description": {
+          "type": ["null", "string"]
+        },
+        "CurrencyCode": {
+          "type": ["null", "string"]
+        },
+        "Breakdown": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "ExcludedTaxAmount": {
+                "type": ["null", "number"]
+              },
+              "IncludedTaxAmount": {
+                "type": ["null", "number"]
+              },
+              "TaxAmount": {
+                "type": ["null", "number"]
+              },
+              "Amount": {
+                "type": ["null", "number"]
+              },
+              "RateMode": {
+                "type": ["null", "string"]
+              },
+              "Quantity": {
+                "type": ["null", "integer"]
+              }
+            }
+          }
+        },
+        "TaxIncluded": { "type": "boolean" },
+        "TotalPrice": {
+          "type": ["null", "number"]
+        },
+        "TotalTaxAmount": {
+          "type": ["null", "number"]
+        },
+        "TotalExtraTaxAmount": {
+          "type": ["null", "number"]
+        },
+        "CancellationPolicyCode": {
+          "type": ["null", "string"]
+        },
+        "GuaranteeCode": {
+          "type": ["null", "string"]
+        },
+        "MarketCode": {
+          "type": ["null", "string"]
+        },
+        "FullStayWithTaxAndAdditionals": {
+          "type": ["null", "number"]
+        }
+      }
+    },
+    "Agency": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "Id": {
+          "type": ["null", "integer"]
+        },
+        "Name": {
+          "type": ["null", "string"]
+        },
+        "EmailAddress": {
+          "type": ["null", "string"]
+        },
+        "Comments": {
+          "type": ["null", "string"]
+        },
+        "VatNumber": {
+          "type": ["null", "string"]
+        },
+        "HotelCode": {
+          "type": ["null", "string"]
+        },
+        "Fax": {
+          "type": ["null", "string"]
+        },
+        "CreatedDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "LastUpdateDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "Addresses": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "City": {
+                "type": ["null", "string"]
+              },
+              "HouseNumber": {
+                "type": ["null", "string"]
+              },
+              "State": {
+                "type": ["null", "string"]
+              },
+              "Street": {
+                "type": ["null", "string"]
+              },
+              "ZipCode": {
+                "type": ["null", "string"]
+              },
+              "CountryCode": {
+                "type": ["null", "string"]
+              },
+              "LanguageCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "PhoneNumbers": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "CountryAccessCode": {
+                "type": ["null", "string"]
+              },
+              "Number": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "ExternalReferences": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "SystemCode": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        },
+        "Attributes": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "StartDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "EndDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "CreateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        }
+      }
+    },
+    "Company": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "Id": {
+          "type": ["null", "integer"]
+        },
+        "Name": {
+          "type": ["null", "string"]
+        },
+        "EmailAddress": {
+          "type": ["null", "string"]
+        },
+        "Comments": {
+          "type": ["null", "string"]
+        },
+        "VatNumber": {
+          "type": ["null", "string"]
+        },
+        "HotelCode": {
+          "type": ["null", "string"]
+        },
+        "Fax": {
+          "type": ["null", "string"]
+        },
+        "CreatedDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "LastUpdateDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "Addresses": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "City": {
+                "type": ["null", "string"]
+              },
+              "HouseNumber": {
+                "type": ["null", "string"]
+              },
+              "State": {
+                "type": ["null", "string"]
+              },
+              "Street": {
+                "type": ["null", "string"]
+              },
+              "ZipCode": {
+                "type": ["null", "string"]
+              },
+              "CountryCode": {
+                "type": ["null", "string"]
+              },
+              "LanguageCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "PhoneNumbers": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "CountryAccessCode": {
+                "type": ["null", "string"]
+              },
+              "Number": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "ExternalReferences": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "SystemCode": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        },
+        "Attributes": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "StartDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "EndDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "CreateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        }
+      }
+    },
+    "SourceCompany": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "Id": {
+          "type": ["null", "integer"]
+        },
+        "Name": {
+          "type": ["null", "string"]
+        },
+        "EmailAddress": {
+          "type": ["null", "string"]
+        },
+        "Comments": {
+          "type": ["null", "string"]
+        },
+        "VatNumber": {
+          "type": ["null", "string"]
+        },
+        "HotelCode": {
+          "type": ["null", "string"]
+        },
+        "Fax": {
+          "type": ["null", "string"]
+        },
+        "CreatedDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "LastUpdateDateTime": {
+          "type": ["null", "string"],
+          "format": "date-time"
+        },
+        "Addresses": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "City": {
+                "type": ["null", "string"]
+              },
+              "HouseNumber": {
+                "type": ["null", "string"]
+              },
+              "State": {
+                "type": ["null", "string"]
+              },
+              "Street": {
+                "type": ["null", "string"]
+              },
+              "ZipCode": {
+                "type": ["null", "string"]
+              },
+              "CountryCode": {
+                "type": ["null", "string"]
+              },
+              "LanguageCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "PhoneNumbers": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "CountryAccessCode": {
+                "type": ["null", "string"]
+              },
+              "Number": {
+                "type": ["null", "string"]
+              },
+              "IsPrimary": { "type": "boolean" },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "Type": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "ExternalReferences": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "SystemCode": {
+                "type": ["null", "string"]
+              }
+            }
+          }
+        },
+        "Attributes": {
+          "type": ["null", "array"],
+          "items": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Code": {
+                "type": ["null", "string"]
+              },
+              "Value": {
+                "type": ["null", "string"]
+              },
+              "TypeCode": {
+                "type": ["null", "string"]
+              },
+              "StartDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "EndDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "CreateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        }
+      }
+    },
+    "ExtraServices": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "Name": {
+            "type": ["null", "string"]
+          },
+          "CurrencyCode": {
+            "type": ["null", "string"]
+          },
+          "GroupTypeCode": {
+            "type": ["null", "string"]
+          },
+          "Breakdown": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "properties": {
+                "Date": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "ExcludedTaxAmount": {
+                  "type": ["null", "number"]
+                },
+                "IncludedTaxAmount": {
+                  "type": ["null", "number"]
+                },
+                "TaxAmount": {
+                  "type": ["null", "number"]
+                },
+                "Amount": {
+                  "type": ["null", "number"]
+                },
+                "RateMode": {
+                  "type": ["null", "string"]
+                },
+                "Quantity": {
+                  "type": ["null", "integer"]
+                }
+              }
+            }
+          },
+          "TaxIncluded": { "type": "boolean" },
+          "TotalPrice": {
+            "type": ["null", "integer"]
+          },
+          "TotalTaxAmount": {
+            "type": ["null", "integer"]
+          },
+          "RateMode": {
+            "type": ["null", "string"]
+          },
+          "Frequency": {
+            "type": ["null", "string"]
+          },
+          "Quantity": {
+            "type": ["null", "integer"]
+          }
+        }
+      }
+    },
+    "Preferences": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "PersonId": {
+            "type": ["null", "integer"]
+          },
+          "ReservationId": {
+            "type": ["null", "integer"]
+          },
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "Value": {
+            "type": ["null", "string"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "Source": {
+            "type": ["null", "string"]
+          },
+          "HotelCode": {
+            "type": ["null", "string"]
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "ExternalReferences": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "SystemCode": {
+            "type": ["null", "string"]
+          }
+        }
+      }
+    },
+    "OtherLinkedPersons": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "RelationType": {
+            "type": ["null", "string"]
+          },
+          "RelationTypeCode": {
+            "type": ["null", "string"]
+          },
+          "ExternalSystemCode": {
+            "type": ["null", "string"]
+          },
+          "Person": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+              "Id": {
+                "type": ["null", "integer"]
+              },
+              "Title": {
+                "type": ["null", "string"]
+              },
+              "Names": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Title": {
+                      "type": ["null", "string"]
+                    },
+                    "FirstName": {
+                      "type": ["null", "string"]
+                    },
+                    "LastName": {
+                      "type": ["null", "string"]
+                    },
+                    "Primary": { "type": "boolean" }
+                  }
+                }
+              },
+              "EmailAddresses": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "Type": {
+                      "type": ["null", "string"]
+                    },
+                    "Value": {
+                      "type": ["null", "string"]
+                    },
+                    "Verified": { "type": "boolean" },
+                    "Source": {
+                      "type": ["null", "string"]
+                    },
+                    "IsPrimary": { "type": "boolean" },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "LanguageCode": {
+                "type": ["null", "string"]
+              },
+              "CountryCode": {
+                "type": ["null", "string"]
+              },
+              "Gender": {
+                "type": ["null", "string"]
+              },
+              "DateOfBirth": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "HotelCode": {
+                "type": ["null", "string"]
+              },
+              "Source": {
+                "type": ["null", "string"]
+              },
+              "JobTitle": {
+                "type": ["null", "string"]
+              },
+              "IsMember": { "type": "boolean" },
+              "NewsletterSubscription": { "type": "boolean" },
+              "Company": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "Name": {
+                      "type": ["null", "string"]
+                    },
+                    "EmailAddress": {
+                      "type": ["null", "string"]
+                    },
+                    "Comments": {
+                      "type": ["null", "string"]
+                    },
+                    "VatNumber": {
+                      "type": ["null", "string"]
+                    },
+                    "HotelCode": {
+                      "type": ["null", "string"]
+                    },
+                    "Fax": {
+                      "type": ["null", "string"]
+                    },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "Addresses": {
+                      "type": ["null", "array"],
+                      "items": {
+                        "type": ["object", "null"],
+                        "additionalProperties": false,
+                        "properties": {
+                          "Id": {
+                            "type": ["null", "integer"]
+                          },
+                          "City": {
+                            "type": ["null", "string"]
+                          },
+                          "HouseNumber": {
+                            "type": ["null", "string"]
+                          },
+                          "State": {
+                            "type": ["null", "string"]
+                          },
+                          "Street": {
+                            "type": ["null", "string"]
+                          },
+                          "ZipCode": {
+                            "type": ["null", "string"]
+                          },
+                          "CountryCode": {
+                            "type": ["null", "string"]
+                          },
+                          "LanguageCode": {
+                            "type": ["null", "string"]
+                          },
+                          "Source": {
+                            "type": ["null", "string"]
+                          },
+                          "Type": {
+                            "type": ["null", "string"]
+                          },
+                          "IsPrimary": { "type": "boolean" },
+                          "CreatedDateTime": {
+                            "type": ["null", "string"],
+                            "format": "date-time"
+                          },
+                          "LastUpdateDateTime": {
+                            "type": ["null", "string"],
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "PhoneNumbers": {
+                      "type": ["null", "array"],
+                      "items": {
+                        "type": ["object", "null"],
+                        "additionalProperties": false,
+                        "properties": {
+                          "Id": {
+                            "type": ["null", "integer"]
+                          },
+                          "CountryAccessCode": {
+                            "type": ["null", "string"]
+                          },
+                          "Number": {
+                            "type": ["null", "string"]
+                          },
+                          "IsPrimary": { "type": "boolean" },
+                          "Source": {
+                            "type": ["null", "string"]
+                          },
+                          "Type": {
+                            "type": ["null", "string"]
+                          },
+                          "CreatedDateTime": {
+                            "type": ["null", "string"],
+                            "format": "date-time"
+                          },
+                          "LastUpdateDateTime": {
+                            "type": ["null", "string"],
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "ExternalReferences": {
+                      "type": ["null", "array"],
+                      "items": {
+                        "type": ["object", "null"],
+                        "additionalProperties": false,
+                        "properties": {
+                          "Code": {
+                            "type": ["null", "string"]
+                          },
+                          "TypeCode": {
+                            "type": ["null", "string"]
+                          },
+                          "SystemCode": {
+                            "type": ["null", "string"]
+                          }
+                        }
+                      }
+                    },
+                    "Attributes": {
+                      "type": ["null", "array"],
+                      "items": {
+                        "type": ["object", "null"],
+                        "additionalProperties": false,
+                        "properties": {
+                          "Id": {
+                            "type": ["null", "integer"]
+                          },
+                          "Code": {
+                            "type": ["null", "string"]
+                          },
+                          "Value": {
+                            "type": ["null", "string"]
+                          },
+                          "TypeCode": {
+                            "type": ["null", "string"]
+                          },
+                          "StartDateTime": {
+                            "type": ["null", "string"],
+                            "format": "date-time"
+                          },
+                          "EndDateTime": {
+                            "type": ["null", "string"],
+                            "format": "date-time"
+                          },
+                          "CreateDateTime": {
+                            "type": ["null", "string"],
+                            "format": "date-time"
+                          },
+                          "LastUpdateDateTime": {
+                            "type": ["null", "string"],
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "CompanyName": {
+                "type": ["null", "string"]
+              },
+              "ExternalReferences": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Code": {
+                      "type": ["null", "string"]
+                    },
+                    "TypeCode": {
+                      "type": ["null", "string"]
+                    },
+                    "SystemCode": {
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              },
+              "Attributes": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "Code": {
+                      "type": ["null", "string"]
+                    },
+                    "Value": {
+                      "type": ["null", "string"]
+                    },
+                    "TypeCode": {
+                      "type": ["null", "string"]
+                    },
+                    "StartDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "EndDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "CreateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "Addresses": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "City": {
+                      "type": ["null", "string"]
+                    },
+                    "HouseNumber": {
+                      "type": ["null", "string"]
+                    },
+                    "State": {
+                      "type": ["null", "string"]
+                    },
+                    "Street": {
+                      "type": ["null", "string"]
+                    },
+                    "ZipCode": {
+                      "type": ["null", "string"]
+                    },
+                    "CountryCode": {
+                      "type": ["null", "string"]
+                    },
+                    "LanguageCode": {
+                      "type": ["null", "string"]
+                    },
+                    "Source": {
+                      "type": ["null", "string"]
+                    },
+                    "Type": {
+                      "type": ["null", "string"]
+                    },
+                    "IsPrimary": { "type": "boolean" },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "PhoneNumbers": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "CountryAccessCode": {
+                      "type": ["null", "string"]
+                    },
+                    "Number": {
+                      "type": ["null", "string"]
+                    },
+                    "IsPrimary": { "type": "boolean" },
+                    "Source": {
+                      "type": ["null", "string"]
+                    },
+                    "Type": {
+                      "type": ["null", "string"]
+                    },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "DataConsents": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "Message": {
+                      "type": ["null", "string"]
+                    },
+                    "Source": {
+                      "type": ["null", "string"]
+                    },
+                    "SubSource": {
+                      "type": ["null", "string"]
+                    },
+                    "Given": { "type": "boolean" },
+                    "Type": {
+                      "type": ["null", "string"]
+                    },
+                    "ValidUntil": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "PaymentMethods": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "TypeCode": {
+                      "type": ["null", "string"]
+                    },
+                    "Code": {
+                      "type": ["null", "string"]
+                    },
+                    "Name": {
+                      "type": ["null", "string"]
+                    },
+                    "Value": {
+                      "type": ["null", "string"]
+                    },
+                    "SubTypeCode": {
+                      "type": ["null", "string"]
+                    },
+                    "PaymentIntegrationCode": {
+                      "type": ["null", "string"]
+                    },
+                    "PaymentIntegrationMerchantCode": {
+                      "type": ["null", "string"]
+                    },
+                    "ExpiryDate": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "Preferences": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "PersonId": {
+                      "type": ["null", "integer"]
+                    },
+                    "ReservationId": {
+                      "type": ["null", "integer"]
+                    },
+                    "Code": {
+                      "type": ["null", "string"]
+                    },
+                    "Value": {
+                      "type": ["null", "string"]
+                    },
+                    "TypeCode": {
+                      "type": ["null", "string"]
+                    },
+                    "Source": {
+                      "type": ["null", "string"]
+                    },
+                    "HotelCode": {
+                      "type": ["null", "string"]
+                    },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "LoyaltyLevels": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "LevelCode": {
+                      "type": ["null", "string"]
+                    },
+                    "Type": {
+                      "type": ["null", "string"]
+                    },
+                    "Rank": {
+                      "type": ["null", "integer"]
+                    },
+                    "ValidFrom": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "ValidUntil": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "Source": {
+                      "type": ["null", "string"]
+                    },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "StaySummaries": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "CurrencyCode": {
+                      "type": ["null", "string"]
+                    },
+                    "HotelCode": {
+                      "type": ["null", "string"]
+                    },
+                    "LastStayDate": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "NumberOfNights": {
+                      "type": ["null", "integer"]
+                    },
+                    "NumberOfStays": {
+                      "type": ["null", "integer"]
+                    },
+                    "StayTotalRevenue": {
+                      "type": ["null", "integer"]
+                    },
+                    "StayTotalRevenueEnterprise": {
+                      "type": ["null", "integer"]
+                    },
+                    "LastStayUnit": {
+                      "type": ["null", "string"]
+                    },
+                    "LastStayRevenue": {
+                      "type": ["null", "integer"]
+                    },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "Documents": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["object", "null"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "Id": {
+                      "type": ["null", "integer"]
+                    },
+                    "PersonId": {
+                      "type": ["null", "integer"]
+                    },
+                    "HotelCode": {
+                      "type": ["null", "string"]
+                    },
+                    "Source": {
+                      "type": ["null", "string"]
+                    },
+                    "Number": {
+                      "type": ["null", "string"]
+                    },
+                    "Nationality": {
+                      "type": ["null", "string"]
+                    },
+                    "Type": {
+                      "type": ["null", "string"]
+                    },
+                    "IssueCity": {
+                      "type": ["null", "string"]
+                    },
+                    "IssueCountry": {
+                      "type": ["null", "string"]
+                    },
+                    "PlaceOfBirth": {
+                      "type": ["null", "string"]
+                    },
+                    "ExpiryDate": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "IssueDate": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "IsPrimary": { "type": "boolean" },
+                    "LastChangedBySystem": {
+                      "type": ["null", "string"]
+                    },
+                    "CreatedDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "LastUpdateDateTime": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "GlobalStays": {
+                "type": ["null", "object"],
+                "additionalProperties": false,
+                "properties": {
+                  "CurrencyCode": {
+                    "type": ["null", "string"]
+                  },
+                  "LastStayDate": {
+                    "type": ["null", "string"],
+                    "format": "date-time"
+                  },
+                  "NumberOfNights": {
+                    "type": ["null", "integer"]
+                  },
+                  "NumberOfStays": {
+                    "type": ["null", "integer"]
+                  },
+                  "StayTotalRevenue": {
+                    "type": ["null", "integer"]
+                  },
+                  "LastStayUnit": {
+                    "type": ["null", "string"]
+                  },
+                  "LastStayHotelCode": {
+                    "type": ["null", "string"]
+                  },
+                  "HotelDiversity": {
+                    "type": ["null", "integer"]
+                  }
+                }
+              },
+              "LastChangedBySystem": {
+                "type": ["null", "string"]
+              },
+              "CreatedDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "LastUpdateDateTime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          }
+        }
+      }
+    },
+    "Contacts": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "Title": {
+            "type": ["null", "string"]
+          },
+          "FirstName": {
+            "type": ["null", "string"]
+          },
+          "LastName": {
+            "type": ["null", "string"]
+          },
+          "EmailAddress": {
+            "type": ["null", "string"]
+          },
+          "PhoneNumber": {
+            "type": ["null", "string"]
+          },
+          "CompanyName": {
+            "type": ["null", "string"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "Street": {
+            "type": ["null", "string"]
+          },
+          "HouseNumber": {
+            "type": ["null", "string"]
+          },
+          "City": {
+            "type": ["null", "string"]
+          },
+          "State": {
+            "type": ["null", "string"]
+          },
+          "ZipCode": {
+            "type": ["null", "string"]
+          },
+          "CountryCode": {
+            "type": ["null", "string"]
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastChangedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "CreatedDateTime": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "LastChangedDateTime": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "BookingDateTime": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "CancellationDateTime": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "PaymentInformations": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Amount": {
+            "type": ["null", "integer"]
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "CurrencyCode": {
+            "type": ["null", "string"]
+          },
+          "RequestedCurrencyCode": {
+            "type": ["null", "string"]
+          },
+          "AmountInRequestedCurrencyCode": {
+            "type": ["null", "number"]
+          },
+          "DueAmount": {
+            "type": ["null", "number"]
+          },
+          "Messages": {
+            "type": ["null", "string"]
+          },
+          "Method": {
+            "type": ["null", "string"]
+          },
+          "Type": {
+            "type": ["null", "string"]
+          },
+          "PaymentToken": {
+            "type": ["null", "string"]
+          },
+          "PspPaymentReference": {
+            "type": ["null", "string"]
+          },
+          "ShopperReference": {
+            "type": ["null", "string"]
+          },
+          "MerchantReference": {
+            "type": ["null", "string"]
+          },
+          "ShopperEmailAddress": {
+            "type": ["null", "string"]
+          },
+          "PaymentSource": {
+            "type": ["null", "string"]
+          },
+          "CardExpMonth": {
+            "type": ["null", "integer"]
+          },
+          "CardExpYear": {
+            "type": ["null", "integer"]
+          },
+          "CardDigits": {
+            "type": ["null", "string"]
+          },
+          "CardScheme": {
+            "type": ["null", "string"]
+          },
+          "OverrodeByMerchantReference": {
+            "type": ["null", "string"]
+          },
+          "TransactionCode": {
+            "type": ["null", "string"]
+          }
+        }
+      }
+    },
+    "PaymentMethods": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "Name": {
+            "type": ["null", "string"]
+          },
+          "Value": {
+            "type": ["null", "string"]
+          },
+          "SubTypeCode": {
+            "type": ["null", "string"]
+          },
+          "PaymentIntegrationCode": {
+            "type": ["null", "string"]
+          },
+          "PaymentIntegrationMerchantCode": {
+            "type": ["null", "string"]
+          },
+          "ExpiryDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "Attributes": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": ["null", "integer"]
+          },
+          "Code": {
+            "type": ["null", "string"]
+          },
+          "Value": {
+            "type": ["null", "string"]
+          },
+          "TypeCode": {
+            "type": ["null", "string"]
+          },
+          "StartDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "EndDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "CreatedDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "LastUpdateDateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "SharerReservationId": {
+      "type": ["null", "integer"]
+    }
+  }
+}

--- a/tap_ireckonu/schemas/sample_schema.json
+++ b/tap_ireckonu/schemas/sample_schema.json
@@ -14,6 +14,15 @@
     },
     "double_field": {
       "type": ["null", "number"]
-    }
+    },
+    "array_type": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["object", "null"],
+        "additionalProperties": false,
+        "properties": {}
+      }
+    },
+    "boolean": { "type": "boolean" }
   }
 }

--- a/tap_ireckonu/streams.py
+++ b/tap_ireckonu/streams.py
@@ -4,18 +4,21 @@ from datetime import datetime, timedelta
 
 LOGGER = singer.get_logger()
 
+
 def end_date_parse(start_date: str) -> str:
-    return datetime.strftime((datetime.strptime(start_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d")
+    return datetime.strftime(
+        (datetime.strptime(start_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d"
+    )
+
 
 class Stream:
     tap_stream_id = None
     key_properties = []
-    replication_method = ''
+    replication_method = ""
     valid_replication_keys = []
-    replication_key = ''
-    object_type = ''
+    replication_key = ""
+    object_type = ""
     today = datetime.strftime(datetime.today(), "%Y-%m-%d")
-
 
     def __init__(self, client, state):
         self.client = client
@@ -26,33 +29,30 @@ class Stream:
 
 
 class CatalogStream(Stream):
-    replication_method = 'INCREMENTAL'
+    replication_method = "INCREMENTAL"
 
 
 class FullTableStream(Stream):
-    replication_method = 'FULL_TABLE'
+    replication_method = "FULL_TABLE"
 
 
 class BulkCompany(CatalogStream):
-    tap_stream_id = 'company'
-    key_properties = ['id']
-    object_type = 'company'
+    tap_stream_id = "company"
+    key_properties = ["id"]
+    object_type = "company"
     page = 0
     page_size = 100
 
     def sync(self):
         ## This is where to setup iteration over each end point
         self.client.fetch_access_token()
-        hotel_code_list = singer.get_bookmark(self.state,
-                                              'MintHouse',
-                                              'Hotel Codes',
-                                              [])
-        start_date = singer.get_bookmark(self.state,
-                                         self.tap_stream_id,
-                                         self.replication_key,
-                                         "2020-10-30")
+        hotel_code_list = singer.get_bookmark(
+            self.state, "MintHouse", "Hotel Codes", []
+        )
+        start_date = singer.get_bookmark(
+            self.state, self.tap_stream_id, self.replication_key, "2020-10-30"
+        )
         end_date = end_date_parse(start_date)
-        
 
         while start_date != self.today:
             response_length = self.page_size
@@ -62,43 +62,42 @@ class BulkCompany(CatalogStream):
                     start_date=start_date,
                     end_date=end_date,
                     page=self.page,
-                    page_size=self.page_size
+                    page_size=self.page_size,
                 )
 
-
-                response_length = len(response['Data'])
-                companies = response['Data']
+                response_length = len(response["Data"])
+                companies = response["Data"]
                 for company in companies:
-                    hotel_code_list.append(company['HotelCode'])
+                    hotel_code_list.append(company["HotelCode"])
                     yield company
-                
+
             start_date = end_date
             end_date = end_date_parse(end_date)
 
-        singer.write_bookmark(self.state,
-                              'MintHouse',
-                              'Hotel Codes',
-                              list(set(filter(lambda x: x != None, hotel_code_list))))
+        singer.write_bookmark(
+            self.state,
+            "MintHouse",
+            "Hotel Codes",
+            list(set(filter(lambda x: x != None, hotel_code_list))),
+        )
 
 
 class BulkPerson(CatalogStream):
-    tap_stream_id = 'person'
-    key_properties = ['id']
-    object_type = 'person'
+    tap_stream_id = "person"
+    key_properties = ["id"]
+    object_type = "person"
     page = 0
     page_size = 100
 
     def sync(self):
         ## This is where to setup iteration over each end point
         self.client.fetch_access_token()
-        hotel_code_list = singer.get_bookmark(self.state,
-                                              'MintHouse',
-                                              'Hotel Codes',
-                                              [])
-        start_date = singer.get_bookmark(self.state,
-                                         self.tap_stream_id,
-                                         self.replication_key,
-                                         "2020-10-30")
+        hotel_code_list = singer.get_bookmark(
+            self.state, "MintHouse", "Hotel Codes", []
+        )
+        start_date = singer.get_bookmark(
+            self.state, self.tap_stream_id, self.replication_key, "2020-10-30"
+        )
         end_date = end_date_parse(start_date)
 
         while start_date != self.today:
@@ -109,42 +108,42 @@ class BulkPerson(CatalogStream):
                     start_date=start_date,
                     end_date=end_date,
                     page=self.page,
-                    page_size=self.page_size
+                    page_size=self.page_size,
                 )
 
-                response_length = len(response['Data'])
-                persons = response['Data']
+                response_length = len(response["Data"])
+                persons = response["Data"]
                 for person in persons:
-                    hotel_code_list.append(person['HotelCode'])
+                    hotel_code_list.append(person["HotelCode"])
                     yield person
 
             start_date = end_date
             end_date = end_date_parse(end_date)
 
-        singer.write_bookmark(self.state,
-                              'MintHouse',
-                              'Hotel Codes',
-                              list(set(filter(lambda x: x != None, hotel_code_list))))
+        singer.write_bookmark(
+            self.state,
+            "MintHouse",
+            "Hotel Codes",
+            list(set(filter(lambda x: x != None, hotel_code_list))),
+        )
 
 
 class BulkFolio(CatalogStream):
-    tap_stream_id = 'folio'
-    key_properties = ['id']
-    object_type = 'folio'
+    tap_stream_id = "folio"
+    key_properties = ["id"]
+    object_type = "folio"
     page = 0
     page_size = 100
 
     def sync(self):
         ## This is where to setup iteration over each end point
         self.client.fetch_access_token()
-        hotel_code_list = singer.get_bookmark(self.state,
-                                              'MintHouse',
-                                              'Hotel Codes',
-                                              [])
-        start_date = singer.get_bookmark(self.state,
-                                         self.tap_stream_id,
-                                         self.replication_key,
-                                         "2020-10-30")
+        hotel_code_list = singer.get_bookmark(
+            self.state, "MintHouse", "Hotel Codes", []
+        )
+        start_date = singer.get_bookmark(
+            self.state, self.tap_stream_id, self.replication_key, "2020-10-30"
+        )
         end_date = end_date_parse(start_date)
 
         while start_date != self.today:
@@ -155,45 +154,45 @@ class BulkFolio(CatalogStream):
                     start_date=start_date,
                     end_date=end_date,
                     page=self.page,
-                    page_size=self.page_size
+                    page_size=self.page_size,
                 )
 
-                response_length = len(response['Data'])
-                folios = response['Data']
+                response_length = len(response["Data"])
+                folios = response["Data"]
                 for folio in folios:
-                    hotel_code_list.append(folio['HotelCode'])
+                    hotel_code_list.append(folio["HotelCode"])
                     yield folio
 
             start_date = end_date
             end_date = end_date_parse(end_date)
 
-        singer.write_bookmark(self.state,
-                              'MintHouse',
-                              'Hotel Codes',
-                              list(set(filter(lambda x: x != None, hotel_code_list))))
+        singer.write_bookmark(
+            self.state,
+            "MintHouse",
+            "Hotel Codes",
+            list(set(filter(lambda x: x != None, hotel_code_list))),
+        )
 
 
 class BulkReservation(CatalogStream):
-    tap_stream_id = 'reservation'
-    key_properties = ['id']
-    object_type = 'reservation'
+    tap_stream_id = "reservation"
+    key_properties = ["id"]
+    object_type = "reservation"
     page = 0
     page_size = 100
 
     def sync(self):
         ## This is where to setup iteration over each end point
         self.client.fetch_access_token()
-        hotel_code_list = singer.get_bookmark(self.state,
-                                              'MintHouse',
-                                              'Hotel Codes',
-                                              [])
+        hotel_code_list = singer.get_bookmark(
+            self.state, "MintHouse", "Hotel Codes", []
+        )
 
         for hotel_code in hotel_code_list:
-            LOGGER.info(f'Starting Reservations for Hotel Code: {hotel_code}')
-            start_date = singer.get_bookmark(self.state,
-                                            self.tap_stream_id,
-                                            self.replication_key,
-                                            "2020-10-30")
+            LOGGER.info(f"Starting Reservations for Hotel Code: {hotel_code}")
+            start_date = singer.get_bookmark(
+                self.state, self.tap_stream_id, self.replication_key, "2020-10-30"
+            )
             end_date = end_date_parse(start_date)
 
             while start_date != self.today:
@@ -205,11 +204,11 @@ class BulkReservation(CatalogStream):
                         start_date=start_date,
                         end_date=end_date,
                         page=self.page,
-                        page_size=self.page_size
+                        page_size=self.page_size,
                     )
 
-                    response_length = len(response['Data'])
-                    reservations = response['Data']
+                    response_length = len(response["Data"])
+                    reservations = response["Data"]
                     for reservation in reservations:
                         yield reservation
 
@@ -218,26 +217,24 @@ class BulkReservation(CatalogStream):
 
 
 class BulkHouseAccount(CatalogStream):
-    tap_stream_id = 'house_account'
-    key_properties = ['id']
-    object_type = 'house_account'
+    tap_stream_id = "house_account"
+    key_properties = ["id"]
+    object_type = "house_account"
     page = 0
     page_size = 100
 
     def sync(self):
         ## This is where to setup iteration over each end point
         self.client.fetch_access_token()
-        hotel_code_list = singer.get_bookmark(self.state,
-                                              'MintHouse',
-                                              'Hotel Codes',
-                                              [])
+        hotel_code_list = singer.get_bookmark(
+            self.state, "MintHouse", "Hotel Codes", []
+        )
 
         for hotel_code in hotel_code_list:
-            LOGGER.info(f'Starting House Accounts for Hotel Code: {hotel_code}')
-            start_date = singer.get_bookmark(self.state,
-                                             self.tap_stream_id,
-                                             self.replication_key,
-                                             "2020-10-30")
+            LOGGER.info(f"Starting House Accounts for Hotel Code: {hotel_code}")
+            start_date = singer.get_bookmark(
+                self.state, self.tap_stream_id, self.replication_key, "2020-10-30"
+            )
             end_date = end_date_parse(start_date)
 
             while start_date != self.today:
@@ -249,11 +246,11 @@ class BulkHouseAccount(CatalogStream):
                         start_date=start_date,
                         end_date=end_date,
                         page=self.page,
-                        page_size=self.page_size
+                        page_size=self.page_size,
                     )
 
-                    response_length = len(response['Data'])
-                    house_accounts = response['Data']
+                    response_length = len(response["Data"])
+                    house_accounts = response["Data"]
                     for house_account in house_accounts:
                         yield house_account
 
@@ -261,11 +258,10 @@ class BulkHouseAccount(CatalogStream):
                 end_date = end_date_parse(end_date)
 
 
-
 STREAMS = {
-    'company': BulkCompany,
-    'person': BulkPerson,
-    'folio': BulkFolio,
-    'reservation': BulkReservation,
-    'house_account': BulkHouseAccount
+    "company": BulkCompany,
+    "person": BulkPerson,
+    "folio": BulkFolio,
+    "reservation": BulkReservation,
+    "house_account": BulkHouseAccount,
 }

--- a/tap_ireckonu/streams.py
+++ b/tap_ireckonu/streams.py
@@ -1,22 +1,27 @@
 import singer
+from singer import logger
+from datetime import datetime, timedelta
 
 LOGGER = singer.get_logger()
 
+def end_date_parse(start_date: str) -> str:
+    return datetime.strftime((datetime.strptime(start_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d")
 
 class Stream:
     tap_stream_id = None
     key_properties = []
     replication_method = ''
     valid_replication_keys = []
-    replication_key = 'last_updated_at'
+    replication_key = ''
     object_type = ''
-    selected = True
+    today = datetime.strftime(datetime.today(), "%Y-%m-%d")
+
 
     def __init__(self, client, state):
         self.client = client
         self.state = state
 
-    def sync(self, *args, **kwargs):
+    def sync_records(self, *args, **kwargs):
         raise NotImplementedError("Sync of child class not implemented")
 
 
@@ -28,33 +33,239 @@ class FullTableStream(Stream):
     replication_method = 'FULL_TABLE'
 
 
-class ENDPOINT1Info(FullTableStream):
-    tap_stream_id = 'ENDPOINT1_info'
-    key_properties = ['ENDPOINT1_id']
-    object_type = 'ENDPOINT1_INFO'
+class BulkCompany(CatalogStream):
+    tap_stream_id = 'company'
+    key_properties = ['id']
+    object_type = 'company'
+    page = 0
+    page_size = 100
 
-    def sync(self, CLIENT_ARUGMENTS):
+    def sync(self):
         ## This is where to setup iteration over each end point
-        response = self.client.fetch_ENDPOINT1s(ENDPOINT1_PARAMETERS)
-        ENDPOINT1s = response.get('data', {}).get('ENDPOINT1_list', [])
-        for ENDPOINT1 in ENDPOINT1s:
-          yield ENDPOINT1
+        self.client.fetch_access_token()
+        hotel_code_list = singer.get_bookmark(self.state,
+                                              'MintHouse',
+                                              'Hotel Codes',
+                                              [])
+        start_date = singer.get_bookmark(self.state,
+                                         self.tap_stream_id,
+                                         self.replication_key,
+                                         "2020-10-30")
+        end_date = end_date_parse(start_date)
+        
+
+        while start_date != self.today:
+            response_length = self.page_size
+            # LOGGER.info(f'Syncing for Date: {start_date}')
+            while response_length >= self.page_size:
+                response = self.client.fetch_bulk_company(
+                    start_date=start_date,
+                    end_date=end_date,
+                    page=self.page,
+                    page_size=self.page_size
+                )
 
 
-class ENDPOINT2Info(FullTableStream):
-    tap_stream_id = 'ENDPOINT2_info'
-    key_properties = ['ENDPOINT2_id']
-    object_type = 'ENDPOINT2_INFO'
+                response_length = len(response['Data'])
+                companies = response['Data']
+                for company in companies:
+                    hotel_code_list.append(company['HotelCode'])
+                    yield company
+                
+            start_date = end_date
+            end_date = end_date_parse(end_date)
 
-    def sync(self, CLIENT_ARUGMENTS):
+        singer.write_bookmark(self.state,
+                              'MintHouse',
+                              'Hotel Codes',
+                              list(set(filter(lambda x: x != None, hotel_code_list))))
+
+
+class BulkPerson(CatalogStream):
+    tap_stream_id = 'person'
+    key_properties = ['id']
+    object_type = 'person'
+    page = 0
+    page_size = 100
+
+    def sync(self):
         ## This is where to setup iteration over each end point
-        response = self.client.fetch_ENDPOINT2s(ENDPOINT2_PARAMETERS)
-        ENDPOINT2s = response.get('data', [])
-        for ENDPOINT2 in ENDPOINT2s:
-          yield ENDPOINT2
+        self.client.fetch_access_token()
+        hotel_code_list = singer.get_bookmark(self.state,
+                                              'MintHouse',
+                                              'Hotel Codes',
+                                              [])
+        start_date = singer.get_bookmark(self.state,
+                                         self.tap_stream_id,
+                                         self.replication_key,
+                                         "2020-10-30")
+        end_date = end_date_parse(start_date)
+
+        while start_date != self.today:
+            response_length = self.page_size
+            # LOGGER.info(f'Syncing for Date: {start_date}')
+            while response_length >= self.page_size:
+                response = self.client.fetch_bulk_person(
+                    start_date=start_date,
+                    end_date=end_date,
+                    page=self.page,
+                    page_size=self.page_size
+                )
+
+                response_length = len(response['Data'])
+                persons = response['Data']
+                for person in persons:
+                    hotel_code_list.append(person['HotelCode'])
+                    yield person
+
+            start_date = end_date
+            end_date = end_date_parse(end_date)
+
+        singer.write_bookmark(self.state,
+                              'MintHouse',
+                              'Hotel Codes',
+                              list(set(filter(lambda x: x != None, hotel_code_list))))
+
+
+class BulkFolio(CatalogStream):
+    tap_stream_id = 'folio'
+    key_properties = ['id']
+    object_type = 'folio'
+    page = 0
+    page_size = 100
+
+    def sync(self):
+        ## This is where to setup iteration over each end point
+        self.client.fetch_access_token()
+        hotel_code_list = singer.get_bookmark(self.state,
+                                              'MintHouse',
+                                              'Hotel Codes',
+                                              [])
+        start_date = singer.get_bookmark(self.state,
+                                         self.tap_stream_id,
+                                         self.replication_key,
+                                         "2020-10-30")
+        end_date = end_date_parse(start_date)
+
+        while start_date != self.today:
+            response_length = self.page_size
+            # LOGGER.info(f'Syncing for Date: {start_date}')
+            while response_length >= self.page_size:
+                response = self.client.fetch_bulk_folio(
+                    start_date=start_date,
+                    end_date=end_date,
+                    page=self.page,
+                    page_size=self.page_size
+                )
+
+                response_length = len(response['Data'])
+                folios = response['Data']
+                for folio in folios:
+                    hotel_code_list.append(folio['HotelCode'])
+                    yield folio
+
+            start_date = end_date
+            end_date = end_date_parse(end_date)
+
+        singer.write_bookmark(self.state,
+                              'MintHouse',
+                              'Hotel Codes',
+                              list(set(filter(lambda x: x != None, hotel_code_list))))
+
+
+class BulkReservation(CatalogStream):
+    tap_stream_id = 'reservation'
+    key_properties = ['id']
+    object_type = 'reservation'
+    page = 0
+    page_size = 100
+
+    def sync(self):
+        ## This is where to setup iteration over each end point
+        self.client.fetch_access_token()
+        hotel_code_list = singer.get_bookmark(self.state,
+                                              'MintHouse',
+                                              'Hotel Codes',
+                                              [])
+
+        for hotel_code in hotel_code_list:
+            LOGGER.info(f'Starting Reservations for Hotel Code: {hotel_code}')
+            start_date = singer.get_bookmark(self.state,
+                                            self.tap_stream_id,
+                                            self.replication_key,
+                                            "2020-10-30")
+            end_date = end_date_parse(start_date)
+
+            while start_date != self.today:
+                response_length = self.page_size
+                # LOGGER.info(f'Syncing for Date: {start_date}')
+                while response_length >= self.page_size:
+                    response = self.client.fetch_bulk_reservation(
+                        hotel_code=hotel_code,
+                        start_date=start_date,
+                        end_date=end_date,
+                        page=self.page,
+                        page_size=self.page_size
+                    )
+
+                    response_length = len(response['Data'])
+                    reservations = response['Data']
+                    for reservation in reservations:
+                        yield reservation
+
+                start_date = end_date
+                end_date = end_date_parse(end_date)
+
+
+class BulkHouseAccount(CatalogStream):
+    tap_stream_id = 'house_account'
+    key_properties = ['id']
+    object_type = 'house_account'
+    page = 0
+    page_size = 100
+
+    def sync(self):
+        ## This is where to setup iteration over each end point
+        self.client.fetch_access_token()
+        hotel_code_list = singer.get_bookmark(self.state,
+                                              'MintHouse',
+                                              'Hotel Codes',
+                                              [])
+
+        for hotel_code in hotel_code_list:
+            LOGGER.info(f'Starting House Accounts for Hotel Code: {hotel_code}')
+            start_date = singer.get_bookmark(self.state,
+                                             self.tap_stream_id,
+                                             self.replication_key,
+                                             "2020-10-30")
+            end_date = end_date_parse(start_date)
+
+            while start_date != self.today:
+                response_length = self.page_size
+                # LOGGER.info(f'Syncing for Date: {start_date}')
+                while response_length >= self.page_size:
+                    response = self.client.fetch_bulk_house_account(
+                        hotel_code=hotel_code,
+                        start_date=start_date,
+                        end_date=end_date,
+                        page=self.page,
+                        page_size=self.page_size
+                    )
+
+                    response_length = len(response['Data'])
+                    house_accounts = response['Data']
+                    for house_account in house_accounts:
+                        yield house_account
+
+                start_date = end_date
+                end_date = end_date_parse(end_date)
+
 
 
 STREAMS = {
-    'ENDPOINT1s': ENDPOINT1Info,
-    'ENDPOINT2s': ENDPOINT2Info
+    'company': BulkCompany,
+    'person': BulkPerson,
+    'folio': BulkFolio,
+    'reservation': BulkReservation,
+    'house_account': BulkHouseAccount
 }

--- a/tap_ireckonu/sync.py
+++ b/tap_ireckonu/sync.py
@@ -1,8 +1,10 @@
 import singer
 from singer import Transformer, metadata
+import time
+from datetime import datetime, timedelta
 
 # The client name needs to be filled in here
-from tap_ireckonu.client import CLIENT_CLASS_NAME
+from tap_ireckonu.client import IreckonuClient
 from tap_ireckonu.streams import STREAMS
 
 LOGGER = singer.get_logger()
@@ -10,13 +12,17 @@ LOGGER = singer.get_logger()
 
 def sync(config, state, catalog):
     # Any client required PARAMETERS to hit the endpoint
-    client = CLIENT_CLASS_NAME(CLIENT_PARAMETERS_HERE)
+    client = IreckonuClient(config)
+    total_records = []
+    stream_rps = []
 
     with Transformer() as transformer:
         for stream in catalog.get_selected_streams(state):
+            stream_start = time.perf_counter()
+            record_count = 0
             tap_stream_id = stream.tap_stream_id
             stream_obj = STREAMS[tap_stream_id](client, state)
-            # replication_key = stream_obj.replication_key
+            replication_key = stream_obj.replication_key
             stream_schema = stream.schema.to_dict()
             stream_metadata = metadata.to_map(stream.metadata)
 
@@ -32,20 +38,48 @@ def sync(config, state, catalog):
                 stream.replication_key
             )
 
-            client = CLIENT_CLASS_NAME(CLIENT_PARAMETERS_HERE)
-            for record in stream_obj.sync(CLIENT_PARAMETERS_HERE):
+            client = IreckonuClient(config)
+            for record in stream_obj.sync():
                 transformed_record = transformer.transform(
                     record, stream_schema, stream_metadata)
-                LOGGER.info(f"Writing record: {transformed_record}")
+
                 singer.write_record(
                     tap_stream_id,
                     transformed_record,
                 )
+                record_count += 1
 
             # If there is a Bookmark or state based key to store
-            state = singer.clear_bookmark(
-                state, tap_stream_id, BOOKMARK_KEY)
-            singer.write_state(state, tap_stream_id, )
+            state = singer.write_bookmark(
+                state, tap_stream_id, 'Last Run Date', datetime.strftime(datetime.today(), "%Y-%m-%d"))
+            stream_stop = time.perf_counter()
+
+            total_records.append(record_count)
+            info, rps = metrics(stream_start, stream_stop, record_count)
+            stream_rps.append(rps)
+            LOGGER.info(f"{info}")
+            singer.write_bookmark(state, tap_stream_id, "metrics", info)
+
+            singer.write_state(state)
 
     state = singer.set_currently_syncing(state, None)
+    overall_rps = overall_metrics(total_records, stream_rps)
+    LOGGER.info(
+        f"Total Records: {sum(total_records)} / Overall RPS: {overall_rps:0.6}"
+    )
+    singer.write_bookmark(state, "Overall", "metrics",
+                          f"Records: {sum(total_records)} / RPS: {overall_rps:0.6}")
     singer.write_state(state)
+
+
+def metrics(start: float, end: float, records: int):
+    elapsed_time = end - start
+    rps = records / elapsed_time
+    info = f"Stream runtime: {elapsed_time:0.6} seconds / Records: {records} / RPS: {rps:0.6}"
+    return info, rps
+
+
+def overall_metrics(records: list, rps_list: list) -> float:
+    stream_count = len(records)
+    total_rps = sum(rps_list)
+    return total_rps / stream_count

--- a/tap_ireckonu/sync.py
+++ b/tap_ireckonu/sync.py
@@ -26,7 +26,7 @@ def sync(config, state, catalog):
             stream_schema = stream.schema.to_dict()
             stream_metadata = metadata.to_map(stream.metadata)
 
-            LOGGER.info('Staring sync for stream: %s', tap_stream_id)
+            LOGGER.info("Staring sync for stream: %s", tap_stream_id)
 
             state = singer.set_currently_syncing(state, tap_stream_id)
             singer.write_state(state)
@@ -35,13 +35,14 @@ def sync(config, state, catalog):
                 tap_stream_id,
                 stream_schema,
                 stream_obj.key_properties,
-                stream.replication_key
+                stream.replication_key,
             )
 
             client = IreckonuClient(config)
             for record in stream_obj.sync():
                 transformed_record = transformer.transform(
-                    record, stream_schema, stream_metadata)
+                    record, stream_schema, stream_metadata
+                )
 
                 singer.write_record(
                     tap_stream_id,
@@ -51,7 +52,11 @@ def sync(config, state, catalog):
 
             # If there is a Bookmark or state based key to store
             state = singer.write_bookmark(
-                state, tap_stream_id, 'Last Run Date', datetime.strftime(datetime.today(), "%Y-%m-%d"))
+                state,
+                tap_stream_id,
+                "Last Run Date",
+                datetime.strftime(datetime.today(), "%Y-%m-%d"),
+            )
             stream_stop = time.perf_counter()
 
             total_records.append(record_count)
@@ -64,11 +69,13 @@ def sync(config, state, catalog):
 
     state = singer.set_currently_syncing(state, None)
     overall_rps = overall_metrics(total_records, stream_rps)
-    LOGGER.info(
-        f"Total Records: {sum(total_records)} / Overall RPS: {overall_rps:0.6}"
+    LOGGER.info(f"Total Records: {sum(total_records)} / Overall RPS: {overall_rps:0.6}")
+    singer.write_bookmark(
+        state,
+        "Overall",
+        "metrics",
+        f"Records: {sum(total_records)} / RPS: {overall_rps:0.6}",
     )
-    singer.write_bookmark(state, "Overall", "metrics",
-                          f"Records: {sum(total_records)} / RPS: {overall_rps:0.6}")
     singer.write_state(state)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,385 +2,296 @@ from dotenv import load_dotenv
 import pytest
 import os
 from requests import Session
+from datetime import datetime, timedelta
 
 load_dotenv()
 
 from tap_ireckonu.client import IreckonuClient
 
-client_id = os.getenv('CLIENT_ID')
-client_secret = os.getenv('CLIENT_SECRET')
+config = {
+    "USERNAME": os.getenv('USERNAME'),
+    "PASSWORD": os.getenv('PASSWORD'),
+    "CLIENT_ID": os.getenv('CLIENT_ID'),
+    "CLIENT_SECRET": os.getenv('CLIENT_SECRET')
+    }
 
 @pytest.fixture()
 def client():
-    yield IreckonuClient(client_id, client_secret)
+    client = IreckonuClient(config)
+    client.fetch_access_token()
 
-def test_ireckonu_client_initialization(client):
-    assert type(client._client) is Session
+    yield client
 
-def test_fetch_created_bulk_company(client):
-    response = client.fetch_created_bulk_company(
-        start_date="2021-03-15T20:31:41.988Z",
-        end_date="2021-04-15T20:31:41.988Z",
-        page=0,
-        page_size=50
-    )
 
-    assert 'Count' in response
-    assert 'Data' in response
+def test_fetch_bulk_company(client):
+    start_date = "2020-10-30"
+    end_date = "2020-10-31"
+    hotel_codes = []
 
-    company = response['Data'][0]
-    assert "Id" in company
-    assert "Name" in company
-    assert "EmailAddress" in company
-    assert "Comments" in company
-    assert "VatNumber" in company
-    assert "HotelCode" in company
-    assert "Fax" in company
-    assert "CreatedDateTime" in company
-    assert "LastUpdateDateTime" in company
-    assert "Addresses" in company
-    assert "PhoneNumbers" in company
-    assert "ExternalReferences" in company
-    assert "Attribues" in company
+    today = datetime.strftime(datetime.today(), "%Y-%m-%d")
 
-def test_fetch_updated_bulk_company(client):
-    response = client.fetch_updated_bulk_company(
-        start_date="2021-03-15T20:31:41.988Z",
-        end_date="2021-04-15T20:31:41.988Z",
-        page=0,
-        page_size=50
-    )
+    while end_date != today:
+        response = client.fetch_bulk_company(
+            start_date=start_date,
+            end_date=end_date,
+            page=0,
+            page_size=50
+        )
 
-    assert 'Count' in response
-    assert 'Data' in response
+        assert 'Count' in response
+        assert 'Data' in response
 
-    company = response['Data'][0]
-    assert "Id" in company
-    assert "Name" in company
-    assert "EmailAddress" in company
-    assert "Comments" in company
-    assert "VatNumber" in company
-    assert "HotelCode" in company
-    assert "Fax" in company
-    assert "CreatedDateTime" in company
-    assert "LastUpdateDateTime" in company
-    assert "Addresses" in company
-    assert "PhoneNumbers" in company
-    assert "ExternalReferences" in company
-    assert "Attribues" in company
+        print(f'{start_date} - Response: {response["Count"]}')
+        if len(response['Data']) > 0:
+            print('Testing Company Data')
+        for company in response['Data']:
+            assert "Id" in company
+            assert "Name" in company
+            assert "EmailAddress" in company
+            assert "Comments" in company
+            assert "VatNumber" in company
+            assert "HotelCode" in company
+            hotel_codes.append(company['HotelCode'])
+            assert "Fax" in company
+            assert "CreatedDateTime" in company
+            assert "LastUpdateDateTime" in company
+            assert "Addresses" in company
+            assert "PhoneNumbers" in company
+            assert "ExternalReferences" in company
+            assert "Attribues" in company
 
-def test_fetch_created_bulk_folio(client):
-    response = client.fetch_created_bulk_folio(
-        start_date="2021-03-15T20:31:41.988Z",
-        end_date="2021-04-15T20:31:41.988Z",
-        page=0,
-        page_size=50
-    )
+        start_date = end_date
+        end_date = datetime.strftime((datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d")
 
-    assert 'Count' in response
-    assert 'Data' in response
+    print(f'{set(hotel_codes)}')
 
-    folio = response['Data'][0]
 
-    assert "Id" in folio
-    assert "HotelCode" in folio
-    assert "ReservationId" in folio
-    assert "Total" in folio
-    assert "VatTotal" in folio
-    assert "InvoiceNumber" in folio
-    assert "AdditionalInvoiceNumber" in folio
-    assert "PrimaryPersonId" in folio
-    assert "AgencyId" in folio
-    assert "CompanyId" in folio
-    assert "SourceCompanyId" in folio
-    assert "System" in folio
-    assert "Status" in folio
-    assert "Address" in folio
-    assert "Lines" in folio
-    assert "CreatedDateTime" in folio
-    assert "LastChangedDateTime" in folio
 
-def test_fetch_updated_bulk_folio(client):
-    response = client.fetch_updated_bulk_folio(
-        start_date="2021-03-15T20:31:41.988Z",
-        end_date="2021-04-15T20:31:41.988Z",
-        page=0,
-        page_size=50
-    )
 
-    assert 'Count' in response
-    assert 'Data' in response
+def test_fetch_bulk_folio(client):
+    start_date = "2020-10-30"
+    end_date = "2020-10-31"
 
-    folio = response['Data'][0]
+    hotel_codes = []
 
-    assert "Id" in folio
-    assert "HotelCode" in folio
-    assert "ReservationId" in folio
-    assert "Total" in folio
-    assert "VatTotal" in folio
-    assert "InvoiceNumber" in folio
-    assert "AdditionalInvoiceNumber" in folio
-    assert "PrimaryPersonId" in folio
-    assert "AgencyId" in folio
-    assert "CompanyId" in folio
-    assert "SourceCompanyId" in folio
-    assert "System" in folio
-    assert "Status" in folio
-    assert "Address" in folio
-    assert "Lines" in folio
-    assert "CreatedDateTime" in folio
-    assert "LastChangedDateTime" in folio
+    today = datetime.strftime(datetime.today(), "%Y-%m-%d")
 
-def test_fetch_created_bulk_house_account(client):
-    response = client.fetch_created_bulk_house_account(
-        start_date="2021-03-15T20:31:41.988Z",
-        end_date="2021-04-15T20:31:41.988Z",
-        page=0,
-        page_size=50
-    )
+    while end_date != today:
+        response = client.fetch_bulk_folio(
+            start_date=start_date,
+            end_date=end_date,
+            page=0,
+            page_size=50
+        )
 
-    assert 'Count' in response
-    assert 'Data' in response
+        assert 'Count' in response
+        assert 'Data' in response
+        print(f'{start_date} - Response: {response["Count"]}')
+        if len(response['Data']) > 0:
+            print('Testing Folio Data')
+        for folio in response['Data']:
+            assert "Id" in folio
+            assert "HotelCode" in folio
+            hotel_codes.append(folio['HotelCode'])
+            assert "ReservationId" in folio
+            assert "Total" in folio
+            assert "VatTotal" in folio
+            assert "InvoiceNumber" in folio
+            assert "AdditionalInvoiceNumber" in folio
+            assert "PrimaryPersonId" in folio
+            assert "AgencyId" in folio
+            assert "CompanyId" in folio
+            assert "SourceCompanyId" in folio
+            assert "System" in folio
+            assert "Status" in folio
+            assert "Address" in folio
+            assert "Lines" in folio
+            assert "CreatedDateTime" in folio
+            assert "LastChangedDateTime" in folio
 
-    house_account = response['Data'][0]
+        start_date = end_date
+        end_date = datetime.strftime(
+            (datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d")
 
-    assert "Id" in house_account
-    assert "CompanyCode" in house_account
-    assert "MarketCode" in house_account
-    assert "Name" in house_account
-    assert "Comments" in house_account
-    assert "SourceCode" in house_account
-    assert "VirtualRoomCode" in house_account
-    assert "HotelCode" in house_account
-    assert "ExternalReferences" in house_account
-    assert "ContactPerson" in house_account
-    assert "PrimaryPerson" in house_account
-    assert "Agency" in house_account
-    assert "Company" in house_account
-    assert "SourceCompany" in house_account
+    print(f'{set(hotel_codes)}')
+
+
+
+
+def test_fetch_bulk_person(client):
+    start_date = "2020-10-30"
+    end_date = "2020-10-31"
+
+    hotel_codes = []
+
+    today = datetime.strftime(datetime.today(), "%Y-%m-%d")
+
+    while end_date != today:
+        response = client.fetch_bulk_person(
+            start_date=start_date,
+            end_date=end_date,
+            page=0,
+            page_size=50
+        )
+
+        assert 'Count' in response
+        assert 'Data' in response
+
+        print(f'{start_date} - Response: {response["Count"]}')
+        if len(response['Data']) > 0:
+            print('Testing Person Data')
+        for person in response['Data']:
+            assert "Id" in person
+            assert "Title" in person
+            assert "Names" in person
+            assert "EmailAddresses" in person
+            assert "LanguageCode" in person
+            assert "CountryCode" in person
+            assert "Gender" in person
+            assert "DateOfBirth" in person
+            assert "HotelCode" in person
+            hotel_codes.append(person['HotelCode'])
+            assert "Source" in person
+            assert "JobTitle" in person
+            assert "IsMember" in person
+            assert "NewsletterSubscription" in person
+            assert "Company" in person
+            assert "CompanyName" in person
+            assert "ExternalReferences" in person
+            assert "Attributes" in person
+            assert "Addresses" in person
+            assert "PhoneNumbers" in person
+            assert "DataConsents" in person
+            assert "PaymentMethods" in person
+            assert "Preferences" in person
+            assert "LoyaltyLevels" in person
+            assert "StaySummaries" in person
+            assert "Documents" in person
+            assert "GlobalStay" in person
+            assert "LastChangedBySystem" in person
+            assert "CreatedDateTime" in person
+            assert "LastUpdateDateTime" in person
+
+        start_date = end_date
+        end_date = datetime.strftime(
+            (datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d")
+
+    print(f'{set(hotel_codes)}')
+
+
+def test_fetch_bulk_house_account(client):
+
+    hotel_codes = ['AMS01', 'NYC01']
+
+    today = datetime.strftime(datetime.today(), "%Y-%m-%d")
+
+    for hotel_code in hotel_codes:
+        start_date = "2020-10-30"
+        end_date = "2020-10-31"
+        while end_date != today:
+            response = client.fetch_bulk_house_account(
+                hotel_code=hotel_code,
+                start_date=start_date,
+                end_date=end_date,
+                page=0,
+                page_size=50
+            )
+
+            assert 'Count' in response
+            assert 'Data' in response
+
+            print(f'{start_date} - Response: {response["Count"]} - Hotel Code: {hotel_code}')
+            if len(response['Data']) > 0:
+                print('Testing House Account Data')
+            for house_account in response['Data']:
+                assert "Id" in house_account
+                assert "CompanyCode" in house_account
+                assert "MarketCode" in house_account
+                assert "Name" in house_account
+                assert "Comments" in house_account
+                assert "SourceCode" in house_account
+                assert "VirtualRoomCode" in house_account
+                assert "HotelCode" in house_account
+                assert "ExternalReferences" in house_account
+                assert "ContactPerson" in house_account
+                assert "PrimaryPerson" in house_account
+                assert "Agency" in house_account
+                assert "Company" in house_account
+                assert "SourceCompany" in house_account
+
+            start_date = end_date
+            end_date = datetime.strftime(
+                (datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d")
     
-def test_fetch_updated_bulk_house_account(client):
-    response = client.fetch_updated_bulk_house_account(
-        start_date="2021-03-15T20:31:41.988Z",
-        end_date="2021-04-15T20:31:41.988Z",
-        page=0,
-        page_size=50
-    )
 
-    assert 'Count' in response
-    assert 'Data' in response
+def test_fetch_bulk_reservation(client):
+    hotel_codes = ['AMS01', 'NYC01']
 
-    house_account = response['Data'][0]
+    today = datetime.strftime(datetime.today(), "%Y-%m-%d")
 
-    assert "Id" in house_account
-    assert "CompanyCode" in house_account
-    assert "MarketCode" in house_account
-    assert "Name" in house_account
-    assert "Comments" in house_account
-    assert "SourceCode" in house_account
-    assert "VirtualRoomCode" in house_account
-    assert "HotelCode" in house_account
-    assert "ExternalReferences" in house_account
-    assert "ContactPerson" in house_account
-    assert "PrimaryPerson" in house_account
-    assert "Agency" in house_account
-    assert "Company" in house_account
-    assert "SourceCompany" in house_account
+    for hotel_code in hotel_codes:
+        start_date = "2020-10-30"
+        end_date = "2020-10-31"
+        while end_date != today:
+            response = client.fetch_bulk_reservation(
+                hotel_code=hotel_code,
+                start_date=start_date,
+                end_date=end_date,
+                page=0,
+                page_size=50
+            )
 
-def test_fetch_created_bulk_person(client):
-    response = client.fetch_created_bulk_person(
-        start_date="2021-03-15T20:31:41.988Z",
-        end_date="2021-04-15T20:31:41.988Z",
-        page=0,
-        page_size=50
-    )
+            assert 'Count' in response
+            assert 'Data' in response
 
-    assert 'Count' in response
-    assert 'Data' in response
+            print(
+                f'{start_date} - Response: {response["Count"]} - Hotel Code: {hotel_code}')
+            if len(response['Data']) > 0:
+                print('Testing Reservation Data')
+            for reservation in response['Data']: 
+                assert "Id" in reservation
+                assert "SubReservations" in reservation
+                assert "ArrivalDate" in reservation
+                assert "DepartureDate" in reservation
+                assert "HotelCode" in reservation
+                assert "UnitCode" in reservation
+                assert "UnitTypeCode" in reservation
+                assert "RequestedUnitTypeCode" in reservation
+                assert "Status" in reservation
+                assert "NumberOfPersons" in reservation
+                assert "NumberOfChildren" in reservation
+                assert "NumberOfInfants" in reservation
+                assert "NumberOfUnits" in reservation
+                assert "NumberOfNights" in reservation
+                assert "Comments" in reservation
+                assert "Source" in reservation
+                assert "SubSource" in reservation
+                assert "GroupCode" in reservation
+                assert "GuaranteeTypeCode" in reservation
+                assert "MarketCode" in reservation
+                assert "PromoCode" in reservation
+                assert "ActualArrivalDate" in reservation
+                assert "ActualDepartureDate" in reservation
+                assert "Booker" in reservation
+                assert "PrimaryGuest" in reservation
+                assert "RatePlan" in reservation
+                assert "Agency" in reservation
+                assert "Company" in reservation
+                assert "SourceCompany" in reservation
+                assert "ExtraServices" in reservation
+                assert "Preferences" in reservation
+                assert "ExternalReferences" in reservation
+                assert "OtherLinkedPersons" in reservation
+                assert "Contacts" in reservation
+                assert "CreatedDateTime" in reservation
+                assert "LastChangedDateTime" in reservation
+                assert "BookingDateTime" in reservation
+                assert "CancellationDateTime" in reservation
+                assert "PaymentInformations" in reservation
+                assert "PaymentMethods" in reservation
+                assert "Attributes" in reservation
+                assert "SharerReservationId" in reservation
 
-    person = response['Data'][0]
-
-    assert "Id" in person
-    assert "Title" in person
-    assert "Names" in person
-    assert "EmailAddresses" in person
-    assert "LanguageCode" in person
-    assert "CountryCode" in person
-    assert "Gender" in person
-    assert "DateOfBirth" in person
-    assert "HotelCode" in person
-    assert "Source" in person
-    assert "JobTitle" in person
-    assert "IsMember" in person
-    assert "NewsletterSubscription" in person
-    assert "Company" in person
-    assert "CompanyName" in person
-    assert "ExternalReferences" in person
-    assert "Attributes" in person
-    assert "Addresses" in person
-    assert "PhoneNumbers" in person
-    assert "DataConsents" in person
-    assert "PaymentMethods" in person
-    assert "Preferences" in person
-    assert "LoyaltyLevels" in person
-    assert "StaySummaries" in person
-    assert "Documents" in person
-    assert "GlobalStay" in person
-    assert "LastChangedBySystem" in person
-    assert "CreatedDateTime" in person
-    assert "LastUpdateDateTime" in person
-
-def test_fetch_updated_bulk_person(client):
-    response = client.fetch_updated_bulk_person(
-        start_date="2021-03-15T20:31:41.988Z",
-        end_date="2021-04-15T20:31:41.988Z",
-        page=0,
-        page_size=50
-    )
-
-    assert 'Count' in response
-    assert 'Data' in response
-
-    person = response['Data'][0]
-
-    assert "Id" in person
-    assert "Title" in person
-    assert "Names" in person
-    assert "EmailAddresses" in person
-    assert "LanguageCode" in person
-    assert "CountryCode" in person
-    assert "Gender" in person
-    assert "DateOfBirth" in person
-    assert "HotelCode" in person
-    assert "Source" in person
-    assert "JobTitle" in person
-    assert "IsMember" in person
-    assert "NewsletterSubscription" in person
-    assert "Company" in person
-    assert "CompanyName" in person
-    assert "ExternalReferences" in person
-    assert "Attributes" in person
-    assert "Addresses" in person
-    assert "PhoneNumbers" in person
-    assert "DataConsents" in person
-    assert "PaymentMethods" in person
-    assert "Preferences" in person
-    assert "LoyaltyLevels" in person
-    assert "StaySummaries" in person
-    assert "Documents" in person
-    assert "GlobalStay" in person
-    assert "LastChangedBySystem" in person
-    assert "CreatedDateTime" in person
-    assert "LastUpdateDateTime" in person
-
-def test_fetch_created_bulk_reservation(client):
-    response = client.fetch_created_bulk_reservation(
-        start_date="2021-03-15T20:31:41.988Z",
-        end_date="2021-04-15T20:31:41.988Z",
-        page=0,
-        page_size=50
-    )
-
-    assert 'Count' in response
-    assert 'Data' in response
-
-    reservation = response['Data'][0]   
-
-    assert "Id" in reservation
-    assert "SubReservations" in reservation
-    assert "ArrivalDate" in reservation
-    assert "DepartureDate" in reservation
-    assert "HotelCode" in reservation
-    assert "UnitCode" in reservation
-    assert "UnitTypeCode" in reservation
-    assert "RequestedUnitTypeCode" in reservation
-    assert "Status" in reservation
-    assert "NumberOfPersons" in reservation
-    assert "NumberOfChildren" in reservation
-    assert "NumberOfInfants" in reservation
-    assert "NumberOfUnits" in reservation
-    assert "NumberOfNights" in reservation
-    assert "Comments" in reservation
-    assert "Source" in reservation
-    assert "SubSource" in reservation
-    assert "GroupCode" in reservation
-    assert "GuaranteeTypeCode" in reservation
-    assert "MarketCode" in reservation
-    assert "PromoCode" in reservation
-    assert "ActualArrivalDate" in reservation
-    assert "ActualDepartureDate" in reservation
-    assert "Booker" in reservation
-    assert "PrimaryGuest" in reservation
-    assert "RatePlan" in reservation
-    assert "Agency" in reservation
-    assert "Company" in reservation
-    assert "SourceCompany" in reservation
-    assert "ExtraServices" in reservation
-    assert "Preferences" in reservation
-    assert "ExternalReferences" in reservation
-    assert "OtherLinkedPersons" in reservation
-    assert "Contacts" in reservation
-    assert "CreatedDateTime" in reservation
-    assert "LastChangedDateTime" in reservation
-    assert "BookingDateTime" in reservation
-    assert "CancellationDateTime" in reservation
-    assert "PaymentInformations" in reservation
-    assert "PaymentMethods" in reservation
-    assert "Attributes" in reservation
-    assert "SharerReservationId" in reservation
-
-def test_fetch_updated_bulk_reservation(client):
-    response = client.fetch_updated_bulk_reservation(
-        start_date="2021-03-15T20:31:41.988Z",
-        end_date="2021-04-15T20:31:41.988Z",
-        page=0,
-        page_size=50
-    )
-
-    assert 'Count' in response
-    assert 'Data' in response
-
-    reservation = response['Data'][0]   
-    
-    assert "Id" in reservation
-    assert "SubReservations" in reservation
-    assert "ArrivalDate" in reservation
-    assert "DepartureDate" in reservation
-    assert "HotelCode" in reservation
-    assert "UnitCode" in reservation
-    assert "UnitTypeCode" in reservation
-    assert "RequestedUnitTypeCode" in reservation
-    assert "Status" in reservation
-    assert "NumberOfPersons" in reservation
-    assert "NumberOfChildren" in reservation
-    assert "NumberOfInfants" in reservation
-    assert "NumberOfUnits" in reservation
-    assert "NumberOfNights" in reservation
-    assert "Comments" in reservation
-    assert "Source" in reservation
-    assert "SubSource" in reservation
-    assert "GroupCode" in reservation
-    assert "GuaranteeTypeCode" in reservation
-    assert "MarketCode" in reservation
-    assert "PromoCode" in reservation
-    assert "ActualArrivalDate" in reservation
-    assert "ActualDepartureDate" in reservation
-    assert "Booker" in reservation
-    assert "PrimaryGuest" in reservation
-    assert "RatePlan" in reservation
-    assert "Agency" in reservation
-    assert "Company" in reservation
-    assert "SourceCompany" in reservation
-    assert "ExtraServices" in reservation
-    assert "Preferences" in reservation
-    assert "ExternalReferences" in reservation
-    assert "OtherLinkedPersons" in reservation
-    assert "Contacts" in reservation
-    assert "CreatedDateTime" in reservation
-    assert "LastChangedDateTime" in reservation
-    assert "BookingDateTime" in reservation
-    assert "CancellationDateTime" in reservation
-    assert "PaymentInformations" in reservation
-    assert "PaymentMethods" in reservation
-    assert "Attributes" in reservation
-    assert "SharerReservationId" in reservation
+            start_date = end_date
+            end_date = datetime.strftime(
+                (datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,386 @@
+from dotenv import load_dotenv
+import pytest
+import os
+from requests import Session
+
+load_dotenv()
+
+from tap_ireckonu.client import IreckonuClient
+
+client_id = os.getenv('CLIENT_ID')
+client_secret = os.getenv('CLIENT_SECRET')
+
+@pytest.fixture()
+def client():
+    yield IreckonuClient(client_id, client_secret)
+
+def test_ireckonu_client_initialization(client):
+    assert type(client._client) is Session
+
+def test_fetch_created_bulk_company(client):
+    response = client.fetch_created_bulk_company(
+        start_date="2021-03-15T20:31:41.988Z",
+        end_date="2021-04-15T20:31:41.988Z",
+        page=0,
+        page_size=50
+    )
+
+    assert 'Count' in response
+    assert 'Data' in response
+
+    company = response['Data'][0]
+    assert "Id" in company
+    assert "Name" in company
+    assert "EmailAddress" in company
+    assert "Comments" in company
+    assert "VatNumber" in company
+    assert "HotelCode" in company
+    assert "Fax" in company
+    assert "CreatedDateTime" in company
+    assert "LastUpdateDateTime" in company
+    assert "Addresses" in company
+    assert "PhoneNumbers" in company
+    assert "ExternalReferences" in company
+    assert "Attribues" in company
+
+def test_fetch_updated_bulk_company(client):
+    response = client.fetch_updated_bulk_company(
+        start_date="2021-03-15T20:31:41.988Z",
+        end_date="2021-04-15T20:31:41.988Z",
+        page=0,
+        page_size=50
+    )
+
+    assert 'Count' in response
+    assert 'Data' in response
+
+    company = response['Data'][0]
+    assert "Id" in company
+    assert "Name" in company
+    assert "EmailAddress" in company
+    assert "Comments" in company
+    assert "VatNumber" in company
+    assert "HotelCode" in company
+    assert "Fax" in company
+    assert "CreatedDateTime" in company
+    assert "LastUpdateDateTime" in company
+    assert "Addresses" in company
+    assert "PhoneNumbers" in company
+    assert "ExternalReferences" in company
+    assert "Attribues" in company
+
+def test_fetch_created_bulk_folio(client):
+    response = client.fetch_created_bulk_folio(
+        start_date="2021-03-15T20:31:41.988Z",
+        end_date="2021-04-15T20:31:41.988Z",
+        page=0,
+        page_size=50
+    )
+
+    assert 'Count' in response
+    assert 'Data' in response
+
+    folio = response['Data'][0]
+
+    assert "Id" in folio
+    assert "HotelCode" in folio
+    assert "ReservationId" in folio
+    assert "Total" in folio
+    assert "VatTotal" in folio
+    assert "InvoiceNumber" in folio
+    assert "AdditionalInvoiceNumber" in folio
+    assert "PrimaryPersonId" in folio
+    assert "AgencyId" in folio
+    assert "CompanyId" in folio
+    assert "SourceCompanyId" in folio
+    assert "System" in folio
+    assert "Status" in folio
+    assert "Address" in folio
+    assert "Lines" in folio
+    assert "CreatedDateTime" in folio
+    assert "LastChangedDateTime" in folio
+
+def test_fetch_updated_bulk_folio(client):
+    response = client.fetch_updated_bulk_folio(
+        start_date="2021-03-15T20:31:41.988Z",
+        end_date="2021-04-15T20:31:41.988Z",
+        page=0,
+        page_size=50
+    )
+
+    assert 'Count' in response
+    assert 'Data' in response
+
+    folio = response['Data'][0]
+
+    assert "Id" in folio
+    assert "HotelCode" in folio
+    assert "ReservationId" in folio
+    assert "Total" in folio
+    assert "VatTotal" in folio
+    assert "InvoiceNumber" in folio
+    assert "AdditionalInvoiceNumber" in folio
+    assert "PrimaryPersonId" in folio
+    assert "AgencyId" in folio
+    assert "CompanyId" in folio
+    assert "SourceCompanyId" in folio
+    assert "System" in folio
+    assert "Status" in folio
+    assert "Address" in folio
+    assert "Lines" in folio
+    assert "CreatedDateTime" in folio
+    assert "LastChangedDateTime" in folio
+
+def test_fetch_created_bulk_house_account(client):
+    response = client.fetch_created_bulk_house_account(
+        start_date="2021-03-15T20:31:41.988Z",
+        end_date="2021-04-15T20:31:41.988Z",
+        page=0,
+        page_size=50
+    )
+
+    assert 'Count' in response
+    assert 'Data' in response
+
+    house_account = response['Data'][0]
+
+    assert "Id" in house_account
+    assert "CompanyCode" in house_account
+    assert "MarketCode" in house_account
+    assert "Name" in house_account
+    assert "Comments" in house_account
+    assert "SourceCode" in house_account
+    assert "VirtualRoomCode" in house_account
+    assert "HotelCode" in house_account
+    assert "ExternalReferences" in house_account
+    assert "ContactPerson" in house_account
+    assert "PrimaryPerson" in house_account
+    assert "Agency" in house_account
+    assert "Company" in house_account
+    assert "SourceCompany" in house_account
+    
+def test_fetch_updated_bulk_house_account(client):
+    response = client.fetch_updated_bulk_house_account(
+        start_date="2021-03-15T20:31:41.988Z",
+        end_date="2021-04-15T20:31:41.988Z",
+        page=0,
+        page_size=50
+    )
+
+    assert 'Count' in response
+    assert 'Data' in response
+
+    house_account = response['Data'][0]
+
+    assert "Id" in house_account
+    assert "CompanyCode" in house_account
+    assert "MarketCode" in house_account
+    assert "Name" in house_account
+    assert "Comments" in house_account
+    assert "SourceCode" in house_account
+    assert "VirtualRoomCode" in house_account
+    assert "HotelCode" in house_account
+    assert "ExternalReferences" in house_account
+    assert "ContactPerson" in house_account
+    assert "PrimaryPerson" in house_account
+    assert "Agency" in house_account
+    assert "Company" in house_account
+    assert "SourceCompany" in house_account
+
+def test_fetch_created_bulk_person(client):
+    response = client.fetch_created_bulk_person(
+        start_date="2021-03-15T20:31:41.988Z",
+        end_date="2021-04-15T20:31:41.988Z",
+        page=0,
+        page_size=50
+    )
+
+    assert 'Count' in response
+    assert 'Data' in response
+
+    person = response['Data'][0]
+
+    assert "Id" in person
+    assert "Title" in person
+    assert "Names" in person
+    assert "EmailAddresses" in person
+    assert "LanguageCode" in person
+    assert "CountryCode" in person
+    assert "Gender" in person
+    assert "DateOfBirth" in person
+    assert "HotelCode" in person
+    assert "Source" in person
+    assert "JobTitle" in person
+    assert "IsMember" in person
+    assert "NewsletterSubscription" in person
+    assert "Company" in person
+    assert "CompanyName" in person
+    assert "ExternalReferences" in person
+    assert "Attributes" in person
+    assert "Addresses" in person
+    assert "PhoneNumbers" in person
+    assert "DataConsents" in person
+    assert "PaymentMethods" in person
+    assert "Preferences" in person
+    assert "LoyaltyLevels" in person
+    assert "StaySummaries" in person
+    assert "Documents" in person
+    assert "GlobalStay" in person
+    assert "LastChangedBySystem" in person
+    assert "CreatedDateTime" in person
+    assert "LastUpdateDateTime" in person
+
+def test_fetch_updated_bulk_person(client):
+    response = client.fetch_updated_bulk_person(
+        start_date="2021-03-15T20:31:41.988Z",
+        end_date="2021-04-15T20:31:41.988Z",
+        page=0,
+        page_size=50
+    )
+
+    assert 'Count' in response
+    assert 'Data' in response
+
+    person = response['Data'][0]
+
+    assert "Id" in person
+    assert "Title" in person
+    assert "Names" in person
+    assert "EmailAddresses" in person
+    assert "LanguageCode" in person
+    assert "CountryCode" in person
+    assert "Gender" in person
+    assert "DateOfBirth" in person
+    assert "HotelCode" in person
+    assert "Source" in person
+    assert "JobTitle" in person
+    assert "IsMember" in person
+    assert "NewsletterSubscription" in person
+    assert "Company" in person
+    assert "CompanyName" in person
+    assert "ExternalReferences" in person
+    assert "Attributes" in person
+    assert "Addresses" in person
+    assert "PhoneNumbers" in person
+    assert "DataConsents" in person
+    assert "PaymentMethods" in person
+    assert "Preferences" in person
+    assert "LoyaltyLevels" in person
+    assert "StaySummaries" in person
+    assert "Documents" in person
+    assert "GlobalStay" in person
+    assert "LastChangedBySystem" in person
+    assert "CreatedDateTime" in person
+    assert "LastUpdateDateTime" in person
+
+def test_fetch_created_bulk_reservation(client):
+    response = client.fetch_created_bulk_reservation(
+        start_date="2021-03-15T20:31:41.988Z",
+        end_date="2021-04-15T20:31:41.988Z",
+        page=0,
+        page_size=50
+    )
+
+    assert 'Count' in response
+    assert 'Data' in response
+
+    reservation = response['Data'][0]   
+
+    assert "Id" in reservation
+    assert "SubReservations" in reservation
+    assert "ArrivalDate" in reservation
+    assert "DepartureDate" in reservation
+    assert "HotelCode" in reservation
+    assert "UnitCode" in reservation
+    assert "UnitTypeCode" in reservation
+    assert "RequestedUnitTypeCode" in reservation
+    assert "Status" in reservation
+    assert "NumberOfPersons" in reservation
+    assert "NumberOfChildren" in reservation
+    assert "NumberOfInfants" in reservation
+    assert "NumberOfUnits" in reservation
+    assert "NumberOfNights" in reservation
+    assert "Comments" in reservation
+    assert "Source" in reservation
+    assert "SubSource" in reservation
+    assert "GroupCode" in reservation
+    assert "GuaranteeTypeCode" in reservation
+    assert "MarketCode" in reservation
+    assert "PromoCode" in reservation
+    assert "ActualArrivalDate" in reservation
+    assert "ActualDepartureDate" in reservation
+    assert "Booker" in reservation
+    assert "PrimaryGuest" in reservation
+    assert "RatePlan" in reservation
+    assert "Agency" in reservation
+    assert "Company" in reservation
+    assert "SourceCompany" in reservation
+    assert "ExtraServices" in reservation
+    assert "Preferences" in reservation
+    assert "ExternalReferences" in reservation
+    assert "OtherLinkedPersons" in reservation
+    assert "Contacts" in reservation
+    assert "CreatedDateTime" in reservation
+    assert "LastChangedDateTime" in reservation
+    assert "BookingDateTime" in reservation
+    assert "CancellationDateTime" in reservation
+    assert "PaymentInformations" in reservation
+    assert "PaymentMethods" in reservation
+    assert "Attributes" in reservation
+    assert "SharerReservationId" in reservation
+
+def test_fetch_updated_bulk_reservation(client):
+    response = client.fetch_updated_bulk_reservation(
+        start_date="2021-03-15T20:31:41.988Z",
+        end_date="2021-04-15T20:31:41.988Z",
+        page=0,
+        page_size=50
+    )
+
+    assert 'Count' in response
+    assert 'Data' in response
+
+    reservation = response['Data'][0]   
+    
+    assert "Id" in reservation
+    assert "SubReservations" in reservation
+    assert "ArrivalDate" in reservation
+    assert "DepartureDate" in reservation
+    assert "HotelCode" in reservation
+    assert "UnitCode" in reservation
+    assert "UnitTypeCode" in reservation
+    assert "RequestedUnitTypeCode" in reservation
+    assert "Status" in reservation
+    assert "NumberOfPersons" in reservation
+    assert "NumberOfChildren" in reservation
+    assert "NumberOfInfants" in reservation
+    assert "NumberOfUnits" in reservation
+    assert "NumberOfNights" in reservation
+    assert "Comments" in reservation
+    assert "Source" in reservation
+    assert "SubSource" in reservation
+    assert "GroupCode" in reservation
+    assert "GuaranteeTypeCode" in reservation
+    assert "MarketCode" in reservation
+    assert "PromoCode" in reservation
+    assert "ActualArrivalDate" in reservation
+    assert "ActualDepartureDate" in reservation
+    assert "Booker" in reservation
+    assert "PrimaryGuest" in reservation
+    assert "RatePlan" in reservation
+    assert "Agency" in reservation
+    assert "Company" in reservation
+    assert "SourceCompany" in reservation
+    assert "ExtraServices" in reservation
+    assert "Preferences" in reservation
+    assert "ExternalReferences" in reservation
+    assert "OtherLinkedPersons" in reservation
+    assert "Contacts" in reservation
+    assert "CreatedDateTime" in reservation
+    assert "LastChangedDateTime" in reservation
+    assert "BookingDateTime" in reservation
+    assert "CancellationDateTime" in reservation
+    assert "PaymentInformations" in reservation
+    assert "PaymentMethods" in reservation
+    assert "Attributes" in reservation
+    assert "SharerReservationId" in reservation

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,11 +9,12 @@ load_dotenv()
 from tap_ireckonu.client import IreckonuClient
 
 config = {
-    "USERNAME": os.getenv('USERNAME'),
-    "PASSWORD": os.getenv('PASSWORD'),
-    "CLIENT_ID": os.getenv('CLIENT_ID'),
-    "CLIENT_SECRET": os.getenv('CLIENT_SECRET')
-    }
+    "USERNAME": os.getenv("USERNAME"),
+    "PASSWORD": os.getenv("PASSWORD"),
+    "CLIENT_ID": os.getenv("CLIENT_ID"),
+    "CLIENT_SECRET": os.getenv("CLIENT_SECRET"),
+}
+
 
 @pytest.fixture()
 def client():
@@ -32,26 +33,23 @@ def test_fetch_bulk_company(client):
 
     while end_date != today:
         response = client.fetch_bulk_company(
-            start_date=start_date,
-            end_date=end_date,
-            page=0,
-            page_size=50
+            start_date=start_date, end_date=end_date, page=0, page_size=50
         )
 
-        assert 'Count' in response
-        assert 'Data' in response
+        assert "Count" in response
+        assert "Data" in response
 
         print(f'{start_date} - Response: {response["Count"]}')
-        if len(response['Data']) > 0:
-            print('Testing Company Data')
-        for company in response['Data']:
+        if len(response["Data"]) > 0:
+            print("Testing Company Data")
+        for company in response["Data"]:
             assert "Id" in company
             assert "Name" in company
             assert "EmailAddress" in company
             assert "Comments" in company
             assert "VatNumber" in company
             assert "HotelCode" in company
-            hotel_codes.append(company['HotelCode'])
+            hotel_codes.append(company["HotelCode"])
             assert "Fax" in company
             assert "CreatedDateTime" in company
             assert "LastUpdateDateTime" in company
@@ -61,11 +59,11 @@ def test_fetch_bulk_company(client):
             assert "Attribues" in company
 
         start_date = end_date
-        end_date = datetime.strftime((datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d")
+        end_date = datetime.strftime(
+            (datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d"
+        )
 
-    print(f'{set(hotel_codes)}')
-
-
+    print(f"{set(hotel_codes)}")
 
 
 def test_fetch_bulk_folio(client):
@@ -78,21 +76,18 @@ def test_fetch_bulk_folio(client):
 
     while end_date != today:
         response = client.fetch_bulk_folio(
-            start_date=start_date,
-            end_date=end_date,
-            page=0,
-            page_size=50
+            start_date=start_date, end_date=end_date, page=0, page_size=50
         )
 
-        assert 'Count' in response
-        assert 'Data' in response
+        assert "Count" in response
+        assert "Data" in response
         print(f'{start_date} - Response: {response["Count"]}')
-        if len(response['Data']) > 0:
-            print('Testing Folio Data')
-        for folio in response['Data']:
+        if len(response["Data"]) > 0:
+            print("Testing Folio Data")
+        for folio in response["Data"]:
             assert "Id" in folio
             assert "HotelCode" in folio
-            hotel_codes.append(folio['HotelCode'])
+            hotel_codes.append(folio["HotelCode"])
             assert "ReservationId" in folio
             assert "Total" in folio
             assert "VatTotal" in folio
@@ -111,11 +106,10 @@ def test_fetch_bulk_folio(client):
 
         start_date = end_date
         end_date = datetime.strftime(
-            (datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d")
+            (datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d"
+        )
 
-    print(f'{set(hotel_codes)}')
-
-
+    print(f"{set(hotel_codes)}")
 
 
 def test_fetch_bulk_person(client):
@@ -128,19 +122,16 @@ def test_fetch_bulk_person(client):
 
     while end_date != today:
         response = client.fetch_bulk_person(
-            start_date=start_date,
-            end_date=end_date,
-            page=0,
-            page_size=50
+            start_date=start_date, end_date=end_date, page=0, page_size=50
         )
 
-        assert 'Count' in response
-        assert 'Data' in response
+        assert "Count" in response
+        assert "Data" in response
 
         print(f'{start_date} - Response: {response["Count"]}')
-        if len(response['Data']) > 0:
-            print('Testing Person Data')
-        for person in response['Data']:
+        if len(response["Data"]) > 0:
+            print("Testing Person Data")
+        for person in response["Data"]:
             assert "Id" in person
             assert "Title" in person
             assert "Names" in person
@@ -150,7 +141,7 @@ def test_fetch_bulk_person(client):
             assert "Gender" in person
             assert "DateOfBirth" in person
             assert "HotelCode" in person
-            hotel_codes.append(person['HotelCode'])
+            hotel_codes.append(person["HotelCode"])
             assert "Source" in person
             assert "JobTitle" in person
             assert "IsMember" in person
@@ -174,14 +165,15 @@ def test_fetch_bulk_person(client):
 
         start_date = end_date
         end_date = datetime.strftime(
-            (datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d")
+            (datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d"
+        )
 
-    print(f'{set(hotel_codes)}')
+    print(f"{set(hotel_codes)}")
 
 
 def test_fetch_bulk_house_account(client):
 
-    hotel_codes = ['AMS01', 'NYC01']
+    hotel_codes = ["AMS01", "NYC01"]
 
     today = datetime.strftime(datetime.today(), "%Y-%m-%d")
 
@@ -194,16 +186,18 @@ def test_fetch_bulk_house_account(client):
                 start_date=start_date,
                 end_date=end_date,
                 page=0,
-                page_size=50
+                page_size=50,
             )
 
-            assert 'Count' in response
-            assert 'Data' in response
+            assert "Count" in response
+            assert "Data" in response
 
-            print(f'{start_date} - Response: {response["Count"]} - Hotel Code: {hotel_code}')
-            if len(response['Data']) > 0:
-                print('Testing House Account Data')
-            for house_account in response['Data']:
+            print(
+                f'{start_date} - Response: {response["Count"]} - Hotel Code: {hotel_code}'
+            )
+            if len(response["Data"]) > 0:
+                print("Testing House Account Data")
+            for house_account in response["Data"]:
                 assert "Id" in house_account
                 assert "CompanyCode" in house_account
                 assert "MarketCode" in house_account
@@ -221,11 +215,13 @@ def test_fetch_bulk_house_account(client):
 
             start_date = end_date
             end_date = datetime.strftime(
-                (datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d")
-    
+                (datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)),
+                "%Y-%m-%d",
+            )
+
 
 def test_fetch_bulk_reservation(client):
-    hotel_codes = ['AMS01', 'NYC01']
+    hotel_codes = ["AMS01", "NYC01"]
 
     today = datetime.strftime(datetime.today(), "%Y-%m-%d")
 
@@ -238,17 +234,18 @@ def test_fetch_bulk_reservation(client):
                 start_date=start_date,
                 end_date=end_date,
                 page=0,
-                page_size=50
+                page_size=50,
             )
 
-            assert 'Count' in response
-            assert 'Data' in response
+            assert "Count" in response
+            assert "Data" in response
 
             print(
-                f'{start_date} - Response: {response["Count"]} - Hotel Code: {hotel_code}')
-            if len(response['Data']) > 0:
-                print('Testing Reservation Data')
-            for reservation in response['Data']: 
+                f'{start_date} - Response: {response["Count"]} - Hotel Code: {hotel_code}'
+            )
+            if len(response["Data"]) > 0:
+                print("Testing Reservation Data")
+            for reservation in response["Data"]:
                 assert "Id" in reservation
                 assert "SubReservations" in reservation
                 assert "ArrivalDate" in reservation
@@ -294,4 +291,6 @@ def test_fetch_bulk_reservation(client):
 
             start_date = end_date
             end_date = datetime.strftime(
-                (datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)), "%Y-%m-%d")
+                (datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)),
+                "%Y-%m-%d",
+            )


### PR DESCRIPTION
# Description :: iReckonu Connector Setup

iReckonu is currently setup to work against the Acceptance API that has limited data.  Change will/may have to be made to adjust to the production database.

Connector links to five endpoints:
- BulkCompany
- BulkPerson
- BulkFolio
- BulkReservation
- BulkHouseAccount

Each of these endpoints operates on a paginated request cycle.  It will query the api based all all records on a given day with a limit of 100 and then offset based on the page count until it receives all the records before moving on to the next day until the backfill is complete.  After that the bookmarking will come into play and pull in regards to a previous bookmarked time until the previous day.

Company, Person, and Folio all log and bookmark their hotel codes in a unique list so that Reservations and House Accounts can have those in their queries as well.

Tests are currently written without any VCR records since the pieces may have to be modified to production.  They are written to cycle through days starting on `2020-10-30` until the current day.  They are written this way in the effort to catch as much data as possible to tested again in the limit acceptance data set.

Bookmarking will have to change in production after larger data sets are tested against to ensure no records are missed in each pull.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Breaking Change
- [x] Testing
- [ ] Documentation

## Environment and Dependencies

- [x] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [ ] No Changes

Black Automatic formatting used